### PR TITLE
 fixed querying for safe address

### DIFF
--- a/safe_transaction_service/notifications/views.py
+++ b/safe_transaction_service/notifications/views.py
@@ -34,7 +34,7 @@ class FirebaseDeviceSafeDeleteView(DestroyAPIView):
     def perform_destroy(self, firebase_device: FirebaseDevice):
         safe_address = self.kwargs['address']
         try:
-            safe_contract = SafeContract.objects.get()
+            safe_contract = SafeContract.objects.get(address=safe_address)
             firebase_device.safes.remove(safe_contract)
         except SafeContract.DoesNotExist:
             logger.info('Cannot remove safe=%s for firebase_device with uuid=%s', safe_address, self.kwargs['pk'])


### PR DESCRIPTION
Fix for the 500 server error that happened when address was not specified.

```python
2020-08-11 09:35:55,797 [ERROR] [MainProcess] Internal Server Error: /api/v1/notifications/devices/799eb559-0128-4013-b356-f4c5f908cc06/safes/0x7348C4a88858Bc3E105150D50860FbcaA0327c2a/

Traceback (most recent call last):

  File "/usr/local/lib/python3.8/site-packages/django/core/handlers/exception.py", line 34, in inner

    response = get_response(request)

  File "/usr/local/lib/python3.8/site-packages/django/core/handlers/base.py", line 115, in _get_response

    response = self.process_exception_by_middleware(e, request)

  File "/usr/local/lib/python3.8/site-packages/django/core/handlers/base.py", line 113, in _get_response

    response = wrapped_callback(request, *callback_args, **callback_kwargs)

  File "/usr/local/lib/python3.8/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view

    return view_func(*args, **kwargs)

  File "/usr/local/lib/python3.8/site-packages/django/views/generic/base.py", line 71, in view

    return self.dispatch(request, *args, **kwargs)

  File "/usr/local/lib/python3.8/site-packages/rest_framework/views.py", line 505, in dispatch

    response = self.handle_exception(exc)

  File "/usr/local/lib/python3.8/site-packages/rest_framework/views.py", line 465, in handle_exception

    self.raise_uncaught_exception(exc)

  File "/usr/local/lib/python3.8/site-packages/rest_framework/views.py", line 476, in raise_uncaught_exception

    raise exc

  File "/usr/local/lib/python3.8/site-packages/rest_framework/views.py", line 502, in dispatch

    response = handler(request, *args, **kwargs)

  File "/usr/local/lib/python3.8/site-packages/rest_framework/generics.py", line 217, in delete

    return self.destroy(request, *args, **kwargs)

  File "/usr/local/lib/python3.8/site-packages/rest_framework/mixins.py", line 91, in destroy

    self.perform_destroy(instance)

  File "/app/safe_transaction_service/notifications/views.py", line 37, in perform_destroy

    safe_contract = SafeContract.objects.get()

  File "/usr/local/lib/python3.8/site-packages/django/db/models/manager.py", line 82, in manager_method

    return getattr(self.get_queryset(), name)(*args, **kwargs)

  File "/usr/local/lib/python3.8/site-packages/django/db/models/query.py", line 419, in get

    raise self.model.MultipleObjectsReturned(

safe_transaction_service.history.models.SafeContract.MultipleObjectsReturned: get() returned more than one SafeContract -- it returned more than 20!
```
