### PR TITLE
Remove new txs on master copy update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ docutils==0.17.1
 drf-yasg[validation]==1.20.0
 ethereum==2.3.2
 firebase-admin==5.0.0
-gnosis-py[django]==3.0.2
+gnosis-py[django]==3.0.3
 gunicorn[gevent]==20.1.0
 hexbytes==0.2.1
 packaging>=20.9

--- a/safe_transaction_service/history/indexers/tx_processor.py
+++ b/safe_transaction_service/history/indexers/tx_processor.py
@@ -154,8 +154,12 @@ class SafeTxProcessor(TxProcessor):
         :return: `True` if migrating from a Master Copy old version to a new version breaks signatures,
         `False` otherwise
         """
+        old_version = Version(Version(old_safe_version).base_version)  # Remove things like -alpha or +L2
+        new_version = Version(Version(new_safe_version).base_version)
+        if new_version < old_version:
+            new_version, old_version = old_version, new_version
         for breaking_version in self.signature_breaking_versions:
-            if Version(old_safe_version) < breaking_version <= Version(new_safe_version):
+            if old_version < breaking_version <= new_version:
                 return True
         return False
 

--- a/safe_transaction_service/history/indexers/tx_processor.py
+++ b/safe_transaction_service/history/indexers/tx_processor.py
@@ -8,6 +8,7 @@ from django.db import transaction
 from eth_typing import ChecksumAddress
 from eth_utils import event_abi_to_log_topic
 from hexbytes import HexBytes
+from packaging.version import Version
 from web3 import Web3
 
 from gnosis.eth import EthereumClient
@@ -81,6 +82,10 @@ class SafeTxProcessor(TxProcessor):
             event_abi_to_log_topic(event.abi) for event in self.safe_tx_module_failure_events
         }
         self.safe_status_cache: Dict[str, SafeStatus] = {}
+        self.signature_breaking_versions = (  # Versions where signing changed
+            Version('1.0.0'),  # Safes >= 1.0.0 Renamed `baseGas` to `dataGas`
+            Version('1.3.0'),  # ChainId was included
+        )
 
     def clear_cache(self, safe_address: Optional[str] = None):
         if safe_address:
@@ -141,6 +146,18 @@ class SafeTxProcessor(TxProcessor):
         if not safe_status:
             logger.error('SafeStatus not found for address=%s', address)
         return safe_status
+
+    def is_version_breaking_signatures(self, old_safe_version: str, new_safe_version: str) -> bool:
+        """
+        :param old_safe_version:
+        :param new_safe_version:
+        :return: `True` if migrating from a Master Copy old version to a new version breaks signatures,
+        `False` otherwise
+        """
+        for breaking_version in self.signature_breaking_versions:
+            if Version(old_safe_version) < breaking_version <= Version(new_safe_version):
+                return True
+        return False
 
     def remove_owner(self, internal_tx: InternalTx, safe_status: SafeStatus, owner: str):
         """
@@ -256,7 +273,12 @@ class SafeTxProcessor(TxProcessor):
             logger.debug('Processing master copy change')
             # TODO Ban address if it doesn't have a valid master copy
             safe_status = self.get_last_safe_status_for_address(contract_address)
+            old_safe_version = self.get_safe_version_from_master_copy(safe_status.master_copy)
             safe_status.master_copy = arguments['_masterCopy']
+            new_safe_version = self.get_safe_version_from_master_copy(safe_status.master_copy)
+            if self.is_version_breaking_signatures(old_safe_version, new_safe_version):
+                # Transactions queued not executed are not valid anymore
+                MultisigTransaction.objects.queued(contract_address).delete()
             self.store_new_safe_status(safe_status, internal_tx)
         elif function_name == 'setFallbackHandler':
             logger.debug('Setting FallbackHandler')

--- a/safe_transaction_service/history/management/commands/setup_service.py
+++ b/safe_transaction_service/history/management/commands/setup_service.py
@@ -59,7 +59,8 @@ TASKS = [
 
 MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
     EthereumNetwork.MAINNET: [
-        # ('0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552', 0, '1.3.0'),
+        ('0x3E5c63644E683549055b9Be8653de26E0B4CD36E', 12504423, '1.3.0+L2'),
+        ('0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552', 12504268, '1.3.0'),
         ('0x6851D6fDFAfD08c0295C392436245E5bc78B0185', 10329734, '1.2.0'),
         ('0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F', 9084503, '1.1.1'),
         ('0xaE32496491b53841efb51829d6f886387708F99B', 8915728, '1.1.0'),
@@ -68,6 +69,7 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ('0xAC6072986E985aaBE7804695EC2d8970Cf7541A2', 6569433, '0.0.2'),
     ],
     EthereumNetwork.RINKEBY: [
+        ('0x3E5c63644E683549055b9Be8653de26E0B4CD36E', 8527380, '1.3.0+L2'),
         ('0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552', 8527381, '1.3.0'),
         ('0x6851D6fDFAfD08c0295C392436245E5bc78B0185', 6723632, '1.2.0'),
         ('0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F', 5590754, '1.1.1'),
@@ -110,33 +112,9 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
     ]
 }
 
-L2_MASTER_COPIES = {
-    EthereumNetwork.MAINNET: [
-        # ('0x3E5c63644E683549055b9Be8653de26E0B4CD36E', 0, '1.3.0')
-    ],
-    EthereumNetwork.RINKEBY: [
-        ('0x3E5c63644E683549055b9Be8653de26E0B4CD36E', 8527380, '1.3.0')
-    ],
-    EthereumNetwork.GOERLI: [
-        # ('0x3E5c63644E683549055b9Be8653de26E0B4CD36E', 0, '1.3.0')
-    ],
-    EthereumNetwork.KOVAN: [
-        # ('0x3E5c63644E683549055b9Be8653de26E0B4CD36E', 0, '1.3.0')
-    ],
-    EthereumNetwork.XDAI: [
-        # ('0x3E5c63644E683549055b9Be8653de26E0B4CD36E', 0, '1.3.0')
-    ],
-    EthereumNetwork.ENERGY_WEB_CHAIN: [
-        # ('0x3E5c63644E683549055b9Be8653de26E0B4CD36E', 0, '1.3.0')
-    ],
-    EthereumNetwork.VOLTA: [
-        # ('0x3E5c63644E683549055b9Be8653de26E0B4CD36E', 0, '1.3.0')
-    ]
-}
-
 PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
     EthereumNetwork.MAINNET: [
-        # ('0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2', 0),  # v1.3.0
+        ('0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2', 12504126),  # v1.3.0
         ('0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B', 9084508),  # v1.1.1
         ('0x50e55Af101C777bA7A1d560a774A82eF002ced9F', 8915731),  # v1.1.0
         ('0x12302fE9c02ff50939BaAaaf415fc226C078613C', 7450116),  # v1.0.0
@@ -191,9 +169,6 @@ class Command(BaseCommand):
         if ethereum_network in MASTER_COPIES:
             self.stdout.write(self.style.SUCCESS(f'Setting up {ethereum_network.name} safe addresses'))
             self._setup_safe_master_copies(MASTER_COPIES[ethereum_network])
-        if ethereum_network in L2_MASTER_COPIES:
-            self.stdout.write(self.style.SUCCESS(f'Setting up {ethereum_network.name} l2 safe addresses'))
-            self._setup_safe_l2_master_copies(L2_MASTER_COPIES[ethereum_network])
         if ethereum_network in PROXY_FACTORIES:
             self.stdout.write(self.style.SUCCESS(f'Setting up {ethereum_network.name} proxy factory addresses'))
             self._setup_safe_proxy_factories(PROXY_FACTORIES[ethereum_network])
@@ -203,32 +178,20 @@ class Command(BaseCommand):
 
     def _setup_safe_master_copies(self, safe_master_copies: Sequence[Tuple[str, int, str]]):
         for address, initial_block_number, version in safe_master_copies:
-            safe_master_copy, _ = SafeMasterCopy.objects.get_or_create(
-                address=address,
-                defaults={
-                    'initial_block_number': initial_block_number,
-                    'tx_block_number': initial_block_number,
-                    'version': version,
-                }
-            )
-            if safe_master_copy.version != version:
-                safe_master_copy.version = version
-                safe_master_copy.save(update_fields=['version'])
-
-    def _setup_safe_l2_master_copies(self, safe_master_copies: Sequence[Tuple[str, int, str]]):
-        # TODO Refactor  _setup_safe_master_copies and _setup_safe_l2_master_copies into one method
-        for address, initial_block_number, version in safe_master_copies:
-            safe_master_copy, _ = SafeL2MasterCopy.objects.get_or_create(
-                address=address,
-                defaults={
-                    'initial_block_number': initial_block_number,
-                    'tx_block_number': initial_block_number,
-                    'version': version,
-                }
-            )
-            if safe_master_copy.version != version:
-                safe_master_copy.version = version
-                safe_master_copy.save(update_fields=['version'])
+            ModelsToInsert = (SafeL2MasterCopy, SafeMasterCopy) if version.endswith('+L2') else (SafeMasterCopy,)
+            for ModelToInsert in ModelsToInsert:
+                safe_master_copy, _ = ModelToInsert.objects.get_or_create(
+                    address=address,
+                    defaults={
+                        'initial_block_number': initial_block_number,
+                        'tx_block_number': initial_block_number,
+                        'version': version,
+                    }
+                )
+                if safe_master_copy.version != version or safe_master_copy.initial_block_number != initial_block_number:
+                    safe_master_copy.version = initial_block_number
+                    safe_master_copy.version = version
+                    safe_master_copy.save(update_fields=['initial_block_number', 'version'])
 
     def _setup_safe_proxy_factories(self, safe_proxy_factories: Sequence[Tuple[str, int]]):
         for address, initial_block_number in safe_proxy_factories:

--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -8,9 +8,11 @@ from django.contrib.postgres.fields import ArrayField
 from django.contrib.postgres.indexes import GinIndex
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, models
-from django.db.models import Case, Count, Index, JSONField, Q, QuerySet, Sum
+from django.db.models import (Case, Count, Index, JSONField, Max, Q, QuerySet,
+                              Sum)
 from django.db.models.expressions import (F, OuterRef, RawSQL, Subquery, Value,
                                           When)
+from django.db.models.functions import Coalesce
 from django.db.models.signals import post_save
 from django.utils.translation import gettext_lazy as _
 
@@ -768,7 +770,7 @@ class MultisigTransactionManager(models.Manager):
 
     def not_indexed_metadata_contract_addresses(self):
         """
-        Find contracts with metadata not indexed
+        Find contracts with metadata (abi, contract name) not indexed
         :return:
         """
         return MultisigTransaction.objects.exclude(
@@ -809,6 +811,25 @@ class MultisigTransactionQuerySet(models.QuerySet):
         ).sorted_reverse_by_internal_tx().values('threshold')
 
         return self.annotate(confirmations_required=Subquery(threshold_query[:1]))
+
+    def queued(self, safe_address: str):
+        """
+        :return: Transactions not executed with safe-nonce greater than the last executed nonce. If no transaction is
+        executed every transaction is returned
+        """
+        subquery = self.executed().filter(
+            safe=safe_address
+        ).values(
+            'safe'
+        ).annotate(
+            max_nonce=Max('nonce')
+        ).values('max_nonce')
+        return self.not_executed().annotate(
+            max_executed_nonce=Coalesce(Subquery(subquery), Value(-1), output_field=Uint256Field())
+        ).filter(
+            nonce__gt=F('max_executed_nonce'),
+            safe=safe_address
+        )
 
 
 class MultisigTransaction(TimeStampedModel):
@@ -1159,7 +1180,7 @@ class SafeStatus(models.Model):
 
     def store_new(self, internal_tx: InternalTx) -> None:
         self.internal_tx = internal_tx
-        return self.save()
+        return self.save(force_insert=True)
 
 
 class WebHookType(Enum):

--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -848,7 +848,7 @@ class MultisigTransaction(TimeStampedModel):
     @property
     def owners(self) -> Optional[List[str]]:
         if not self.signatures:
-            return None
+            return []
         else:
             signatures = bytes(self.signatures)
             safe_signatures = SafeSignature.parse_signature(signatures, self.safe_tx_hash)

--- a/safe_transaction_service/history/serializers.py
+++ b/safe_transaction_service/history/serializers.py
@@ -659,7 +659,7 @@ class AnalyticsMultisigTxsBySafeResponseSerializer(serializers.Serializer):
     transactions = serializers.IntegerField()
 
 
-class _AllTransactionsSchemaSerializer(serializers.Serializer):
+class AllTransactionsSchemaSerializer(serializers.Serializer):
     """
     Just for the purpose of documenting, don't use it
     """

--- a/safe_transaction_service/history/tests/test_commands.py
+++ b/safe_transaction_service/history/tests/test_commands.py
@@ -9,7 +9,7 @@ from django_celery_beat.models import PeriodicTask
 
 from gnosis.eth.ethereum_client import EthereumClient, EthereumNetwork
 
-from ..models import ProxyFactory, SafeMasterCopy
+from ..models import ProxyFactory, SafeL2MasterCopy, SafeMasterCopy
 
 
 class TestCommands(TestCase):
@@ -66,6 +66,10 @@ class TestCommands(TestCase):
         last_proxy_factory = ProxyFactory.objects.get(address=last_proxy_factory_address)
         self.assertEqual(last_proxy_factory.initial_block_number, last_proxy_factory_initial_block)
         self.assertEqual(last_proxy_factory.tx_block_number, last_proxy_factory_initial_block)
+
+        self.assertEqual(SafeMasterCopy.objects.count(), 8)
+        self.assertEqual(SafeL2MasterCopy.objects.count(), 1)
+        self.assertEqual(ProxyFactory.objects.count(), 4)
 
     def test_setup_service_rinkeby(self):
         self._test_setup_service(EthereumNetwork.RINKEBY)

--- a/safe_transaction_service/history/tests/test_models.py
+++ b/safe_transaction_service/history/tests/test_models.py
@@ -94,7 +94,7 @@ class TestModelMixins(TestCase):
 class TestMultisigTransaction(TestCase):
     def test_multisig_transaction_owners(self):
         multisig_transaction = MultisigTransactionFactory(signatures=None)
-        self.assertIsNone(multisig_transaction.owners)
+        self.assertEqual(multisig_transaction.owners, [])
 
         account = Account.create()
         multisig_transaction.signatures = account.signHash(multisig_transaction.safe_tx_hash)['signature']

--- a/safe_transaction_service/history/tests/test_tx_processor.py
+++ b/safe_transaction_service/history/tests/test_tx_processor.py
@@ -226,6 +226,18 @@ class TestSafeTxProcessor(TestCase):
         self.assertFalse(tx_processor.is_version_breaking_signatures('1.1.0', '1.2.0'))
         self.assertFalse(tx_processor.is_version_breaking_signatures('0.0.1', '0.9.0'))
 
+        # Reversed
+        self.assertTrue(tx_processor.is_version_breaking_signatures('1.1.1', '0.0.1'))
+        self.assertTrue(tx_processor.is_version_breaking_signatures('1.3.0', '0.0.1'))
+        self.assertTrue(tx_processor.is_version_breaking_signatures('1.3.0', '0.0.1'))
+        self.assertTrue(tx_processor.is_version_breaking_signatures('1.3.0', '1.0.0'))
+        self.assertTrue(tx_processor.is_version_breaking_signatures('1.3.0', '1.1.1'))
+        self.assertTrue(tx_processor.is_version_breaking_signatures('1.3.0', '1.2.0'))
+        self.assertTrue(tx_processor.is_version_breaking_signatures('1.4.0', '1.2.1'))
+        self.assertFalse(tx_processor.is_version_breaking_signatures('1.2.2', '1.0.0'))
+        self.assertFalse(tx_processor.is_version_breaking_signatures('1.2.0', '1.1.0'))
+        self.assertFalse(tx_processor.is_version_breaking_signatures('0.9.0', '0.0.1'))
+
     def test_tx_processor_change_master_copy(self):
         tx_processor = SafeTxProcessorProvider()
         owner = Account.create().address

--- a/safe_transaction_service/history/tests/test_tx_processor.py
+++ b/safe_transaction_service/history/tests/test_tx_processor.py
@@ -15,7 +15,8 @@ from ..models import (InternalTxDecoded, ModuleTransaction,
                       MultisigConfirmation, MultisigTransaction, SafeContract,
                       SafeStatus)
 from .factories import (EthereumTxFactory, InternalTxDecodedFactory,
-                        MultisigConfirmationFactory)
+                        MultisigConfirmationFactory,
+                        MultisigTransactionFactory, SafeMasterCopyFactory)
 from .mocks.traces import call_trace
 
 logger = logging.getLogger(__name__)
@@ -211,3 +212,44 @@ class TestSafeTxProcessor(TestCase):
         ethereum_tx = EthereumTxFactory(logs=logs)
         self.assertTrue(tx_processor.is_failed(ethereum_tx, safe_tx_hash))
         self.assertFalse(tx_processor.is_failed(ethereum_tx, Web3.keccak(text='hola').hex()))
+
+    def test_tx_is_version_breaking_signatures(self):
+        tx_processor = SafeTxProcessorProvider()
+        self.assertTrue(tx_processor.is_version_breaking_signatures('0.0.1', '1.1.1'))
+        self.assertTrue(tx_processor.is_version_breaking_signatures('0.0.1', '1.3.0'))
+        self.assertTrue(tx_processor.is_version_breaking_signatures('0.0.1', '1.4.0'))
+        self.assertTrue(tx_processor.is_version_breaking_signatures('1.0.0', '1.3.0'))
+        self.assertTrue(tx_processor.is_version_breaking_signatures('1.1.1', '1.3.0'))
+        self.assertTrue(tx_processor.is_version_breaking_signatures('1.2.0', '1.3.0'))
+        self.assertTrue(tx_processor.is_version_breaking_signatures('1.2.1', '1.4.0'))
+        self.assertFalse(tx_processor.is_version_breaking_signatures('1.0.0', '1.2.2'))
+        self.assertFalse(tx_processor.is_version_breaking_signatures('1.1.0', '1.2.0'))
+        self.assertFalse(tx_processor.is_version_breaking_signatures('0.0.1', '0.9.0'))
+
+    def test_tx_processor_change_master_copy(self):
+        tx_processor = SafeTxProcessorProvider()
+        owner = Account.create().address
+        safe_address = Account.create().address
+        fallback_handler = Account.create().address
+        threshold = 1
+        safe_1_1_0_master_copy = SafeMasterCopyFactory(version='1.1.0')
+        safe_1_2_0_master_copy = SafeMasterCopyFactory(version='1.2.0')
+        safe_1_3_0_master_copy = SafeMasterCopyFactory(version='1.3.0')
+        tx_processor.process_decoded_transaction(
+            InternalTxDecodedFactory(function_name='setup', owner=owner, threshold=threshold,
+                                     fallback_handler=fallback_handler,
+                                     internal_tx__to=safe_1_1_0_master_copy.address,
+                                     internal_tx___from=safe_address)
+        )
+        tx_processor.process_decoded_transactions(
+            [
+                InternalTxDecodedFactory(function_name='execTransaction',
+                                         internal_tx___from=safe_address),
+                InternalTxDecodedFactory(function_name='changeMasterCopy', master_copy=safe_1_2_0_master_copy,
+                                         internal_tx___from=safe_address)
+            ])
+        self.assertEqual(MultisigTransaction.objects.get().nonce, 0)
+        MultisigTransactionFactory(nonce=1,
+                                   ethereum_tx=None)  # This will not be deleted as execTransaction will insert a tx with nonce=1
+        MultisigTransactionFactory(nonce=2,
+                                   ethereum_tx=none)  # This will be deleted

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -89,10 +89,10 @@ class AnalyticsMultisigTxsBySafeListView(ListAPIView):
 class AllTransactionsListView(ListAPIView):
     filter_backends = (django_filters.rest_framework.DjangoFilterBackend, OrderingFilter)
     pagination_class = pagination.SmallPagination
-    serializer_class = serializers._AllTransactionsSchemaSerializer  # Just for docs, not used
+    serializer_class = serializers.AllTransactionsSchemaSerializer  # Just for docs, not used
 
-    _schema_queued_param = openapi.Parameter('executed', openapi.IN_QUERY, type=openapi.TYPE_BOOLEAN, default=False,
-                                             description='If `True` only executed transactions are returned')
+    _schema_executed_param = openapi.Parameter('executed', openapi.IN_QUERY, type=openapi.TYPE_BOOLEAN, default=False,
+                                               description='If `True` only executed transactions are returned')
     _schema_queued_param = openapi.Parameter('queued', openapi.IN_QUERY, type=openapi.TYPE_BOOLEAN, default=True,
                                              description='If `True` transactions with `nonce >= Safe current nonce` '
                                                          'are also returned')
@@ -100,7 +100,7 @@ class AllTransactionsListView(ListAPIView):
                                               description='If `True` just trusted transactions are shown (indexed, '
                                                           'added by a delegate or with at least one confirmation)')
     _schema_200_response = openapi.Response('A list with every element with the structure of one of these transaction'
-                                            'types', serializers._AllTransactionsSchemaSerializer)
+                                            'types', serializers.AllTransactionsSchemaSerializer)
 
     def get_parameters(self) -> Tuple[bool, bool, bool]:
         """
@@ -133,7 +133,7 @@ class AllTransactionsListView(ListAPIView):
 
     @swagger_auto_schema(responses={200: _schema_200_response,
                                     422: 'code = 1: Checksum address validation failed'},
-                         manual_parameters=[_schema_queued_param, _schema_trusted_param])
+                         manual_parameters=[_schema_executed_param, _schema_queued_param, _schema_trusted_param])
     def get(self, request, *args, **kwargs):
         """
         Returns a paginated list of transactions for a Safe. The list has different structures depending on the


### PR DESCRIPTION
### What was wrong?
Signatures on v1.3.0 are not compatible with the ones on v1.2.0, so queued transactions became invalid when Safe master copy is updated.

### How was it fixed?
- Remove new txs on master copy update when signing is invalid (updating/downgrading to/from `v1.0.0` or `v1.3.0`).
- Closes issue #260 