### PR TITLE
Added chain id

### DIFF
--- a/safe_transaction_service/notifications/tasks.py
+++ b/safe_transaction_service/notifications/tasks.py
@@ -9,6 +9,7 @@ from safe_transaction_service.history.models import (MultisigConfirmation,
                                                      SafeStatus, WebHookType)
 from safe_transaction_service.utils.redis import get_redis
 from safe_transaction_service.utils.utils import close_gevent_db_connection
+from safe_transaction_service.utils.ethereum import get_ethereum_network
 
 from .clients.firebase_client import FirebaseClientPool
 from .models import FirebaseDevice, FirebaseDeviceOwner
@@ -172,6 +173,7 @@ def send_notification_owner_task(address: str, safe_tx_hash: str):
             'type': WebHookType.CONFIRMATION_REQUEST.name,
             'address': address,
             'safeTxHash': safe_tx_hash,
+            'chainId': str(get_ethereum_network().value),
         }
         # Make sure notification has not been sent before
         duplicate_notification = DuplicateNotification(address, payload)


### PR DESCRIPTION
### What was wrong?
The `CONFIRMATION_REQUEST` notification was missing the `chainId` parameter that is present in other notifications.
As a result, the client can't find appropriate safe to show this notification.

<!--Related to Issue # -->

### How was it fixed?
Added the information similar to how it was added in the `history/signals.py`