### PR TITLE
Fix duplicate mypy requirment declaration

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,3 @@ flake8
 isort
 ipdb
 ipython
-mypy


### PR DESCRIPTION
- Remove `mypy` from `requirements-dev.txt`
- `mypy` is declared in both `requirements-dev.txt` and `requirements-test.txt`. Since `requirements-dev.txt` depends on `requirements-test.txt` this would lead to an error where duplicate dependencies were provided
