### PR TITLE
Fix setup modules

### DIFF
--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -670,9 +670,15 @@ class InternalTxDecodedQuerySet(models.QuerySet):
 
     def order_by_processing_queue(self):
         """
-        :return: Transactions ordered to be processed. First older transactions
+        :return: Transactions ordered to be processed. First `setup` and then older transactions
         """
-        return self.order_by(
+        return self.annotate(
+            is_setup=Case(
+                When(function_name='setup', then=Value(0)),
+                default=Value(1),
+            )
+        ).order_by(
+            'is_setup',
             'internal_tx__ethereum_tx__block_id',
             'internal_tx__ethereum_tx__transaction_index',
             'internal_tx__trace_address',

--- a/safe_transaction_service/history/tests/test_models.py
+++ b/safe_transaction_service/history/tests/test_models.py
@@ -325,6 +325,24 @@ class TestInternalTx(TestCase):
 
 
 class TestInternalTxDecoded(TestCase):
+    def test_order_by_processing_queue(self):
+        self.assertQuerysetEqual(InternalTxDecoded.objects.order_by_processing_queue(), [])
+        ethereum_tx = EthereumTxFactory()
+        internal_tx_decoded_1 = InternalTxDecodedFactory(internal_tx__trace_address='1',
+                                                         internal_tx__ethereum_tx=ethereum_tx)
+        internal_tx_decoded_0 = InternalTxDecodedFactory(internal_tx__trace_address='0',
+                                                         internal_tx__ethereum_tx=ethereum_tx)
+        internal_tx_decoded_5 = InternalTxDecodedFactory(internal_tx__trace_address='5',
+                                                         internal_tx__ethereum_tx=ethereum_tx)
+
+        self.assertQuerysetEqual(InternalTxDecoded.objects.order_by_processing_queue(),
+                                 [internal_tx_decoded_0, internal_tx_decoded_1, internal_tx_decoded_5])
+
+        internal_tx_decoded_5.function_name = 'setup'
+        internal_tx_decoded_5.save()
+        self.assertQuerysetEqual(InternalTxDecoded.objects.order_by_processing_queue(),
+                                 [internal_tx_decoded_5, internal_tx_decoded_0, internal_tx_decoded_1])
+
     def test_safes_pending_to_be_processed(self):
         self.assertCountEqual(InternalTxDecoded.objects.safes_pending_to_be_processed(), [])
 


### PR DESCRIPTION
### What was wrong?

Closes issue #348 

### How was it fixed?
As multiple events can be emitted before the `SafeSetup` event (using custom `to` and `data` during Safe creation) `SafeSetup` event should be processed first

@gnosis/safe-services
