### PR TITLE
Add L2 attribute to master-copies endpoint

### DIFF
--- a/safe_transaction_service/history/serializers.py
+++ b/safe_transaction_service/history/serializers.py
@@ -519,6 +519,7 @@ class MasterCopyResponseSerializer(serializers.Serializer):
     deployer = serializers.CharField()
     deployed_block_number = serializers.IntegerField(source='initial_block_number')
     last_indexed_block_number = serializers.IntegerField(source='tx_block_number')
+    l2 = serializers.BooleanField()
 
 
 class OwnerResponseSerializer(serializers.Serializer):

--- a/safe_transaction_service/history/tests/test_views.py
+++ b/safe_transaction_service/history/tests/test_views.py
@@ -1470,12 +1470,13 @@ class TestViews(SafeTestCaseMixin, APITestCase):
              'version': safe_master_copy.version,
              'deployer': safe_master_copy.deployer,
              'deployed_block_number': deployed_block_number,
-             'last_indexed_block_number': last_indexed_block_number
+             'last_indexed_block_number': last_indexed_block_number,
+             'l2': False,
              }
         ]
         self.assertCountEqual(response.data, expected)
 
-        safe_master_copy = SafeMasterCopyFactory()
+        safe_master_copy = SafeMasterCopyFactory(l2=True)
         response = self.client.get(reverse('v1:history:master-copies'))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         expected += [
@@ -1484,6 +1485,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
              'deployer': safe_master_copy.deployer,
              'deployed_block_number': 0,
              'last_indexed_block_number': 0,
+             'l2': True,
              }
         ]
 


### PR DESCRIPTION
I reminded that this attribute was present in DB and we were not returning it (cc @fmrsabino)
