### PR TITLE
Set version 3.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ docutils==0.17.1
 drf-yasg[validation]==1.20.0
 ethereum==2.3.2
 firebase-admin==5.0.2
-gnosis-py[django]==3.2.2
+gnosis-py[django]==3.3.1
 gunicorn[gevent]==20.1.0
 hexbytes==0.2.2
 packaging>=21.0

--- a/safe_transaction_service/__init__.py
+++ b/safe_transaction_service/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.25"
+__version__ = "3.2.0"
 __version_info__ = tuple(
     [
         int(num) if num.isdigit() else num


### PR DESCRIPTION
### What was wrong?

- Update Gnosis-py to v3.3.1 (use multicall)
- Improves `/balances` and `safe` information endpoints (related to #321)


@gnosis/safe-services
