### PR TITLE
Install wheel before other dependencies

### DIFF
--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex \
 		" \
     && apt-get update \
     && apt-get install -y --no-install-recommends $buildDeps \
+    && pip install -U --no-cache-dir wheel setuptools pip \
     && pip install --no-cache-dir -r requirements.txt \
     && apt-get purge -y --auto-remove $buildDeps \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
Install wheel before other dependencies when building the docker image. If not, wheel packages cannot be used
