### PR TITLE
Add support for native coin to /tokens/price/usd

### DIFF
--- a/safe_transaction_service/tokens/services/price_service.py
+++ b/safe_transaction_service/tokens/services/price_service.py
@@ -11,7 +11,6 @@ from cache_memoize import cache_memoize
 from cachetools import TTLCache, cachedmethod
 from celery.utils.log import get_task_logger
 from eth_typing import ChecksumAddress
-from gnosis.eth.constants import NULL_ADDRESS
 from redis import Redis
 
 from gnosis.eth import EthereumClient, EthereumClientProvider
@@ -248,14 +247,6 @@ class PriceService:
         except CannotGetPrice:
             logger.warning('Cannot get network ether price', exc_info=True)
             eth_price = 0
-
-        # If the token is the native one (NULL_ADDRESS) we can return the eth_price immediately
-        if len(token_addresses) == 1 and token_addresses[0] == NULL_ADDRESS:
-            yield FiatPriceWithTimestamp(
-                fiat_price=eth_price,
-                fiat_code=
-                FiatCode.USD, timestamp=timezone.now()
-            )
 
         for token_eth_values_with_timestamp in self.get_cached_token_eth_values(token_addresses):
             yield FiatPriceWithTimestamp(eth_price * token_eth_values_with_timestamp.eth_value,

--- a/safe_transaction_service/tokens/services/price_service.py
+++ b/safe_transaction_service/tokens/services/price_service.py
@@ -11,6 +11,7 @@ from cache_memoize import cache_memoize
 from cachetools import TTLCache, cachedmethod
 from celery.utils.log import get_task_logger
 from eth_typing import ChecksumAddress
+from gnosis.eth.constants import NULL_ADDRESS
 from redis import Redis
 
 from gnosis.eth import EthereumClient, EthereumClientProvider
@@ -247,6 +248,14 @@ class PriceService:
         except CannotGetPrice:
             logger.warning('Cannot get network ether price', exc_info=True)
             eth_price = 0
+
+        # If the token is the native one (NULL_ADDRESS) we can return the eth_price immediately
+        if len(token_addresses) == 1 and token_addresses[0] == NULL_ADDRESS:
+            yield FiatPriceWithTimestamp(
+                fiat_price=eth_price,
+                fiat_code=
+                FiatCode.USD, timestamp=timezone.now()
+            )
 
         for token_eth_values_with_timestamp in self.get_cached_token_eth_values(token_addresses):
             yield FiatPriceWithTimestamp(eth_price * token_eth_values_with_timestamp.eth_value,

--- a/safe_transaction_service/tokens/services/price_service.py
+++ b/safe_transaction_service/tokens/services/price_service.py
@@ -14,6 +14,7 @@ from eth_typing import ChecksumAddress
 from redis import Redis
 
 from gnosis.eth import EthereumClient, EthereumClientProvider
+from gnosis.eth.constants import NULL_ADDRESS
 from gnosis.eth.ethereum_client import EthereumNetwork
 from gnosis.eth.oracles import (AaveOracle, BalancerOracle,
                                 ComposedPriceOracle, CurveOracle, KyberOracle,
@@ -163,7 +164,7 @@ class PriceService:
         :param token_address:
         :return: Current ether value for a given `token_address`
         """
-        if token_address == '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE':  # Ether
+        if token_address == '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE' or token_address == NULL_ADDRESS:  # Ether
             return 1.
 
         for oracle in self.enabled_price_oracles:

--- a/safe_transaction_service/tokens/tests/test_views.py
+++ b/safe_transaction_service/tokens/tests/test_views.py
@@ -116,3 +116,12 @@ class TestTokenViews(SafeTestCaseMixin, APITestCase):
             self.assertEqual(response.data['fiat_code'], 'USD')
             self.assertEqual(response.data['fiat_price'], str(fiat_price_with_timestamp.fiat_price))
             self.assertTrue(response.data['timestamp'])
+
+    @mock.patch.object(PriceService, 'get_eth_usd_price', autospec=True, return_value=12)
+    def test_token_price_view_address_0(self, get_eth_usd_price):
+        token_address = "0x0000000000000000000000000000000000000000"
+        response = self.client.get(reverse('v1:tokens:price-usd', args=(token_address,)))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['fiat_code'], 'USD')
+        self.assertEqual(response.data['fiat_price'], str(12))
+        self.assertTrue(response.data['timestamp'])

--- a/safe_transaction_service/tokens/tests/test_views.py
+++ b/safe_transaction_service/tokens/tests/test_views.py
@@ -117,11 +117,13 @@ class TestTokenViews(SafeTestCaseMixin, APITestCase):
             self.assertEqual(response.data['fiat_price'], str(fiat_price_with_timestamp.fiat_price))
             self.assertTrue(response.data['timestamp'])
 
-    @mock.patch.object(PriceService, 'get_eth_usd_price', autospec=True, return_value=12)
-    def test_token_price_view_address_0(self, get_eth_usd_price):
+    def test_token_price_view_address_0(self):
         token_address = "0x0000000000000000000000000000000000000000"
+
         response = self.client.get(reverse('v1:tokens:price-usd', args=(token_address,)))
+
+        # Native token should be retrieved even if it is not part of the Token table
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['fiat_code'], 'USD')
-        self.assertEqual(response.data['fiat_price'], str(12))
+        self.assertTrue(response.data['fiat_price'])
         self.assertTrue(response.data['timestamp'])

--- a/safe_transaction_service/tokens/views.py
+++ b/safe_transaction_service/tokens/views.py
@@ -3,6 +3,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 
 import django_filters.rest_framework
+from gnosis.eth.constants import NULL_ADDRESS
 from rest_framework import response, status
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.generics import ListAPIView, RetrieveAPIView
@@ -65,7 +66,8 @@ class TokenPriceView(APIView):
                                            'message': 'Invalid ethereum address',
                                            'arguments': [address]})
 
-        if not Token.objects.filter(address=address).exists():
+        # NULL_ADDRESS does not have to be stored in the Token table
+        if not Token.objects.filter(address=address).exists() and address != NULL_ADDRESS:
             raise Http404
         fiat_price_with_timestamp = next(PriceServiceProvider().get_cached_usd_values([address]))
         serializer = self.serializer_class(data={'fiat_code': fiat_price_with_timestamp.fiat_code.name,

--- a/safe_transaction_service/tokens/views.py
+++ b/safe_transaction_service/tokens/views.py
@@ -3,13 +3,14 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 
 import django_filters.rest_framework
-from gnosis.eth.constants import NULL_ADDRESS
 from rest_framework import response, status
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from web3 import Web3
+
+from gnosis.eth.constants import NULL_ADDRESS
 
 from . import filters, serializers
 from .models import Token


### PR DESCRIPTION
- Add support for native coin fiat price in ` /tokens/<address>/price/usd`
- In order to retrieve the native coin of the chain tied to this service, the address to be used should be `0x0000000000000000000000000000000000000000` so from the client perspective the endpoint path would be `/tokens/0x0000000000000000000000000000000000000000/price/usd`
- If an error occurs when fetching the new price, `0` is returned instead. This is line with the other token prices results in case of failure. 