### PR TITLE
Feature: Add enzyme oracle to composed price oracles

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 if __name__ == '__main__':
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings.local')
+    os.environ.setdefault('DJANGO_DOT_ENV_FILE', '.env')
 
     try:
         from django.core.management import execute_from_command_line

--- a/manage.py
+++ b/manage.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 if __name__ == '__main__':
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings.local')
-    os.environ.setdefault('DJANGO_DOT_ENV_FILE', '.env')
 
     try:
         from django.core.management import execute_from_command_line

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ docutils==0.17.1
 drf-yasg[validation]==1.20.0
 ethereum==2.3.2
 firebase-admin==5.0.2
-gnosis-py[django]==3.4.0
+gnosis-py[django]==3.4.1
 gunicorn[gevent]==20.1.0
 hexbytes==0.2.2
 packaging>=21.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ docutils==0.17.1
 drf-yasg[validation]==1.20.0
 ethereum==2.3.2
 firebase-admin==5.0.2
-gnosis-py[django]==3.3.4
+gnosis-py[django]==3.4.0
 gunicorn[gevent]==20.1.0
 hexbytes==0.2.2
 packaging>=21.0

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -5,6 +5,6 @@ set -euo pipefail
 docker-compose -f docker-compose.yml -f docker-compose.dev.yml build --force-rm db redis ganache
 docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --no-start db redis ganache
 docker restart safe-transaction-service_db_1 safe-transaction-service_redis_1 safe-transaction-service_ganache_1
-sleep 2
+sleep 10
 DJANGO_SETTINGS_MODULE=config.settings.test DJANGO_DOT_ENV_FILE=.env.test python manage.py check
 DJANGO_SETTINGS_MODULE=config.settings.test DJANGO_DOT_ENV_FILE=.env.test pytest -rxXs

--- a/safe_transaction_service/history/tests/utils.py
+++ b/safe_transaction_service/history/tests/utils.py
@@ -6,13 +6,20 @@ import requests
 
 def just_test_if_mainnet_node() -> str:
     mainnet_node_url = os.environ.get('ETHEREUM_MAINNET_NODE')
-    if hasattr(just_test_if_mainnet_node, 'checked'):  # Just check mainnet node first time
+    if hasattr(just_test_if_mainnet_node, 'checked'):  # Just check node first time
         return mainnet_node_url
 
     if not mainnet_node_url:
-        pytest.skip("Mainnet node not defined, cannot test oracles", allow_module_level=True)
-    elif requests.post(mainnet_node_url).status_code == 404:
-        pytest.skip("Cannot connect to mainnet node", allow_module_level=True)
-
+        pytest.skip('Mainnet node not defined, cannot test oracles', allow_module_level=True)
+    else:
+        try:
+            if not requests.post(mainnet_node_url, timeout=5,
+                                 json={'jsonrpc': '2.0',
+                                       'method': 'eth_blockNumber',
+                                       'params': [],
+                                       'id': 1}).ok:
+                pytest.skip('Cannot connect to mainnet node', allow_module_level=True)
+        except IOError:
+            pytest.skip('Problem connecting to the mainnet node', allow_module_level=True)
     just_test_if_mainnet_node.checked = True
     return mainnet_node_url

--- a/safe_transaction_service/history/tests/utils.py
+++ b/safe_transaction_service/history/tests/utils.py
@@ -11,7 +11,7 @@ def just_test_if_mainnet_node() -> str:
 
     if not mainnet_node_url:
         pytest.skip("Mainnet node not defined, cannot test oracles", allow_module_level=True)
-    elif requests.get(mainnet_node_url).status_code == 404:
+    elif requests.post(mainnet_node_url).status_code == 404:
         pytest.skip("Cannot connect to mainnet node", allow_module_level=True)
 
     just_test_if_mainnet_node.checked = True

--- a/safe_transaction_service/tokens/services/price_service.py
+++ b/safe_transaction_service/tokens/services/price_service.py
@@ -23,6 +23,7 @@ from gnosis.eth.oracles import (AaveOracle, BalancerOracle,
                                 PricePoolOracle, SushiswapOracle,
                                 UnderlyingToken, UniswapOracle,
                                 UniswapV2Oracle, YearnOracle)
+from gnosis.eth.oracles.oracles import EnzymeOracle
 
 from safe_transaction_service.utils.redis import get_redis
 
@@ -73,6 +74,7 @@ class PriceService:
         self.uniswap_v2_oracle = UniswapV2Oracle(self.ethereum_client)
         self.pool_together_oracle = PoolTogetherOracle(self.ethereum_client)
         self.yearn_oracle = YearnOracle(self.ethereum_client)
+        self.enzyme_oracle = EnzymeOracle(self.ethereum_client)
         self.aave_oracle = AaveOracle(self.ethereum_client, self.uniswap_v2_oracle)
         self.balancer_oracle = BalancerOracle(self.ethereum_client, self.uniswap_v2_oracle)
         self.mooniswap_oracle = MooniswapOracle(self.ethereum_client, self.uniswap_v2_oracle)
@@ -100,7 +102,7 @@ class PriceService:
     @cached_property
     def enabled_composed_price_oracles(self) -> Tuple[ComposedPriceOracle]:
         if self.ethereum_network == EthereumNetwork.MAINNET:
-            return self.curve_oracle, self.yearn_oracle, self.pool_together_oracle
+            return self.curve_oracle, self.yearn_oracle, self.pool_together_oracle, self.enzyme_oracle
         else:
             return tuple()
 
@@ -210,7 +212,7 @@ class PriceService:
             try:
                 return oracle.get_underlying_tokens(token_address)
             except OracleException:
-                logger.info('Cannot get eth value for token-address=%s from %s', token_address,
+                logger.info('Cannot get an underlying token for token-address=%s from %s', token_address,
                             oracle.__class__.__name__)
 
     def get_cached_token_eth_values(self,

--- a/safe_transaction_service/tokens/services/price_service.py
+++ b/safe_transaction_service/tokens/services/price_service.py
@@ -17,13 +17,12 @@ from gnosis.eth import EthereumClient, EthereumClientProvider
 from gnosis.eth.constants import NULL_ADDRESS
 from gnosis.eth.ethereum_client import EthereumNetwork
 from gnosis.eth.oracles import (AaveOracle, BalancerOracle,
-                                ComposedPriceOracle, CurveOracle, KyberOracle,
-                                MooniswapOracle, OracleException,
+                                ComposedPriceOracle, CurveOracle, EnzymeOracle,
+                                KyberOracle, MooniswapOracle, OracleException,
                                 PoolTogetherOracle, PriceOracle,
                                 PricePoolOracle, SushiswapOracle,
                                 UnderlyingToken, UniswapOracle,
                                 UniswapV2Oracle, YearnOracle)
-from gnosis.eth.oracles.oracles import EnzymeOracle
 
 from safe_transaction_service.utils.redis import get_redis
 


### PR DESCRIPTION
### What was wrong?

- Closes #384 
- Also sets the default env file for manage.py and increases sleep time in `run_tests.py.` Let me know if you want it as a separate PR

### How was it fixed?

- Adds EnzymeOracle from gnosis-py 3.4.0 to composed price oracles.

@gnosis/safe-services

Waiting for https://github.com/gnosis/gnosis-py/pull/87 to be merged