### PR TITLE
Add force script name for nested paths on nginx

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -38,6 +38,8 @@ USE_I18N = True
 USE_L10N = True
 # https://docs.djangoproject.com/en/dev/ref/settings/#use-tz
 USE_TZ = True
+# https://docs.djangoproject.com/en/3.2/ref/settings/#force-script-name
+FORCE_SCRIPT_NAME = env('FORCE_SCRIPT_NAME', default=None)
 
 # DATABASES
 # ------------------------------------------------------------------------------
@@ -112,7 +114,7 @@ MIDDLEWARE = [
 STATIC_ROOT = str(ROOT_DIR / "staticfiles")
 
 # https://docs.djangoproject.com/en/dev/ref/settings/#static-url
-STATIC_URL = '/static/'
+STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#std:setting-STATICFILES_DIRS
 STATICFILES_DIRS = [
     str(APPS_DIR / 'static'),


### PR DESCRIPTION
### What was wrong?

Application was not compatible with nginx paths. Now `FORCE_SCRIPT_NAME` can be set as an environment variable to add a base path for all the project

@fmrsabino this must be implemented also in the `config-service` so @jpalvarezl can use it in `safe-infrastructure`