### PR TITLE
Fix coveralls

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -69,11 +69,8 @@ jobs:
         COINMARKETCAP_API_TOKEN: ${{ secrets.COINMARKETCAP_API_TOKEN }}
     - name: Send results to coveralls
       continue-on-error: true  # Ignore coveralls problems
-      if: ${{ env.COVERALLS_REPO_TOKEN }}
-      run: |
-        coveralls
+      run: coveralls
       env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Required for coveralls
   docker-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What was wrong?

Coveralls is not working, `COVERALLS_REPO_TOKEN` is not needed anymore

### How was it fixed?

Don't use `COVERALLS_REPO_TOKEN`

@gnosis/safe-services
 