### PR TITLE
Do migrations on the worker

### DIFF
--- a/docker/web/celery/worker/run.sh
+++ b/docker/web/celery/worker/run.sh
@@ -9,6 +9,11 @@ else
     log_level="info"
 fi
 
-sleep 10  # Wait for migrations
+echo "==> $(date +%H:%M:%S) ==> Migrating Django models... "
+python manage.py migrate --noinput
+
+echo "==> $(date +%H:%M:%S) ==> Setting up service... "
+python manage.py setup_service
+
 echo "==> $(date +%H:%M:%S) ==> Running Celery worker <=="
 exec celery -A config.celery_app worker --loglevel $log_level --pool=gevent --concurrency=120

--- a/docker/web/run_web.sh
+++ b/docker/web/run_web.sh
@@ -2,12 +2,6 @@
 
 set -euo pipefail
 
-echo "==> $(date +%H:%M:%S) ==> Migrating Django models... "
-python manage.py migrate --noinput
-
-echo "==> $(date +%H:%M:%S) ==> Setting up service... "
-python manage.py setup_service &
-
 echo "==> $(date +%H:%M:%S) ==> Collecting statics... "
 DOCKER_SHARED_DIR=/nginx
 rm -rf $DOCKER_SHARED_DIR/*


### PR DESCRIPTION
Only one worker is fired up, so there are no problems of concurrent workers running as it happens with the web pod
