### PR TITLE
Tell apart ERC20/ERC721 looking at token contract

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -69,7 +69,7 @@ jobs:
         COINMARKETCAP_API_TOKEN: ${{ secrets.COINMARKETCAP_API_TOKEN }}
     - name: Send results to coveralls
       continue-on-error: true  # Ignore coveralls problems
-      run: coveralls
+      run: coveralls --service=github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Required for coveralls
   docker-deploy:

--- a/safe_transaction_service/history/admin.py
+++ b/safe_transaction_service/history/admin.py
@@ -3,6 +3,7 @@ from typing import Optional
 from django.contrib import admin
 from django.db.models import F, Q
 from django.db.models.functions import Greatest
+from django.db.transaction import atomic
 
 from hexbytes import HexBytes
 
@@ -111,12 +112,26 @@ class TokenTransferAdmin(admin.ModelAdmin):
 
 @admin.register(ERC20Transfer)
 class ERC20TransferAdmin(TokenTransferAdmin):
-    pass
+    actions = ["to_erc721"]
+
+    @admin.action(description="Convert to ERC721 Transfer")
+    @atomic
+    def to_erc721(self, request, queryset):
+        for element in queryset:
+            element.to_erc721_transfer().save()
+        queryset.delete()
 
 
 @admin.register(ERC721Transfer)
 class ERC721TransferAdmin(TokenTransferAdmin):
-    pass
+    actions = ["to_erc20"]
+
+    @admin.action(description="Convert to ERC20 Transfer")
+    @atomic
+    def to_erc20(self, request, queryset):
+        for element in queryset:
+            element.to_erc20_transfer().save()
+        queryset.delete()
 
 
 @admin.register(EthereumTx)

--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -404,7 +404,7 @@ class ERC20Transfer(TokenTransfer):
         unique_together = (("ethereum_tx", "log_index"),)
 
     def __str__(self):
-        return f"Token Transfer from={self._from} to={self.to} value={self.value}"
+        return f"ERC20 Transfer from={self._from} to={self.to} value={self.value}"
 
     @classmethod
     def from_decoded_event(cls, event_data: EventData) -> Union["ERC20Transfer"]:
@@ -425,6 +425,16 @@ class ERC20Transfer(TokenTransfer):
             raise ValueError(
                 f"Not supported EventData, `value` not present {event_data}"
             )
+
+    def to_erc721_transfer(self):
+        return ERC721Transfer(
+            ethereum_tx=self.ethereum_tx,
+            address=self.address,
+            _from=self._from,
+            to=self.to,
+            log_index=self.log_index,
+            token_id=self.value,
+        )
 
 
 class ERC721TransferManager(TokenTransferManager):
@@ -483,7 +493,9 @@ class ERC721Transfer(TokenTransfer):
         unique_together = (("ethereum_tx", "log_index"),)
 
     def __str__(self):
-        return f"Token Transfer from={self._from} to={self.to} token_id={self.token_id}"
+        return (
+            f"ERC721 Transfer from={self._from} to={self.to} token_id={self.token_id}"
+        )
 
     @classmethod
     def from_decoded_event(cls, event_data: EventData) -> Union["ERC721Transfer"]:
@@ -508,6 +520,16 @@ class ERC721Transfer(TokenTransfer):
     @property
     def value(self) -> Decimal:
         return self.token_id
+
+    def to_erc20_transfer(self):
+        return ERC20Transfer(
+            ethereum_tx=self.ethereum_tx,
+            address=self.address,
+            _from=self._from,
+            to=self.to,
+            log_index=self.log_index,
+            value=self.token_id,
+        )
 
 
 class InternalTxManager(BulkCreateSignalMixin, models.Manager):

--- a/safe_transaction_service/history/models.py
+++ b/safe_transaction_service/history/models.py
@@ -519,6 +519,9 @@ class ERC721Transfer(TokenTransfer):
 
     @property
     def value(self) -> Decimal:
+        """
+        Behave as a ERC20Transfer so it's easier to handle
+        """
         return self.token_id
 
     def to_erc20_transfer(self):

--- a/safe_transaction_service/history/tests/test_erc20_events_indexer.py
+++ b/safe_transaction_service/history/tests/test_erc20_events_indexer.py
@@ -76,8 +76,22 @@ class TestErc20EventsIndexer(EthereumTestCaseMixin, TestCase):
             event["args"]["tokenId"] = event["args"].pop("value")
             original_event = copy.deepcopy(event)
             event["args"]["unknown"] = event["args"].pop("tokenId")
-            event["args"]["unknown"] = original_event["args"]["tokenId"]
 
+            self.assertEqual(
+                erc20_events_indexer._process_decoded_element(event), original_event
+            )
+
+        event = self.ethereum_client.erc20.get_total_transfer_history(
+            from_block=block_number, to_block=block_number
+        )[0]
+        with mock.patch.object(
+            Erc20EventsIndexer, "_is_erc20", autospec=True, return_value=True
+        ):
+            # Convert event to erc721
+            original_event = copy.deepcopy(event)
+            event["args"]["tokenId"] = event["args"].pop("value")
+
+            # ERC721 event will be converted to ERC20
             self.assertEqual(
                 erc20_events_indexer._process_decoded_element(event), original_event
             )

--- a/safe_transaction_service/history/tests/test_models.py
+++ b/safe_transaction_service/history/tests/test_models.py
@@ -227,6 +227,30 @@ class TestEthereumTx(TestCase):
 
 
 class TestTokenTransfer(TestCase):
+    def test_transfer_to_erc721(self):
+        erc20_transfer = ERC20TransferFactory()
+        self.assertEqual(ERC721Transfer.objects.count(), 0)
+        erc20_transfer.to_erc721_transfer().save()
+        self.assertEqual(ERC721Transfer.objects.count(), 1)
+        erc721_transfer = ERC721Transfer.objects.get()
+        self.assertEqual(erc721_transfer.ethereum_tx_id, erc20_transfer.ethereum_tx_id)
+        self.assertEqual(erc721_transfer.address, erc20_transfer.address)
+        self.assertEqual(erc721_transfer.log_index, erc20_transfer.log_index)
+        self.assertEqual(erc721_transfer.to, erc20_transfer.to)
+        self.assertEqual(erc721_transfer.token_id, erc20_transfer.value)
+
+    def test_transfer_to_erc20(self):
+        erc721_transfer = ERC721TransferFactory()
+        self.assertEqual(ERC20Transfer.objects.count(), 0)
+        erc721_transfer.to_erc20_transfer().save()
+        self.assertEqual(ERC20Transfer.objects.count(), 1)
+        erc20_transfer = ERC721Transfer.objects.get()
+        self.assertEqual(erc721_transfer.ethereum_tx_id, erc20_transfer.ethereum_tx_id)
+        self.assertEqual(erc721_transfer.address, erc20_transfer.address)
+        self.assertEqual(erc721_transfer.log_index, erc20_transfer.log_index)
+        self.assertEqual(erc721_transfer.to, erc20_transfer.to)
+        self.assertEqual(erc721_transfer.token_id, erc20_transfer.value)
+
     def test_erc20_events(self):
         safe_address = Account.create().address
         e1 = ERC20TransferFactory(to=safe_address)


### PR DESCRIPTION
Sometimes ERC721 don't follow the standard `Transfer` event, not indexing the `tokenId`. Now when processing every event the token address will be check for `decimals`
