### PR TITLE
Only one reindexing time

### DIFF
--- a/safe_transaction_service/__init__.py
+++ b/safe_transaction_service/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.4.6"
+__version__ = "3.4.7"
 __version_info__ = tuple(
     [
         int(num) if num.isdigit() else num

--- a/safe_transaction_service/history/management/commands/setup_service.py
+++ b/safe_transaction_service/history/management/commands/setup_service.py
@@ -84,7 +84,7 @@ TASKS = [
     CeleryTaskConfiguration(
         "safe_transaction_service.history.tasks.process_decoded_internal_txs_task",
         "Process Internal Txs",
-        2,
+        20,
         IntervalSchedule.MINUTES,
     ),
     CeleryTaskConfiguration(

--- a/safe_transaction_service/history/tests/test_tasks.py
+++ b/safe_transaction_service/history/tests/test_tasks.py
@@ -154,10 +154,21 @@ class TestTasks(TestCase):
                         cm.output[1],
                     )
                     self.assertIn(
-                        f"Safe-address={safe_address} Last known not corrupted SafeStatus with nonce=0 on block={safe_status_0.internal_tx.ethereum_tx.block_id} , reindexing until block={safe_status_5.block_number}",
+                        f"Safe-address={safe_address} Processing traces again",
                         cm.output[2],
                     )
                     self.assertIn(
-                        f"Safe-address={safe_address} Processing traces again",
+                        f"Safe-address={safe_address} Last known not corrupted SafeStatus with nonce=0 on "
+                        f"block={safe_status_0.internal_tx.ethereum_tx.block_id} , "
+                        f"reindexing until block={safe_status_5.block_number}",
                         cm.output[3],
+                    )
+                    self.assertIn(
+                        f"Reindexing master copies from-block={safe_status_0.internal_tx.ethereum_tx.block_id} "
+                        f"to-block={safe_status_5.block_number}",
+                        cm.output[4],
+                    )
+                    self.assertIn(
+                        f"Safe-address={safe_address} Processing traces again after reindexing",
+                        cm.output[5],
                     )

--- a/safe_transaction_service/utils/tasks.py
+++ b/safe_transaction_service/utils/tasks.py
@@ -82,9 +82,11 @@ def only_one_running_task(
     with redis.lock(
         lock_name, blocking_timeout=blocking_timeout, timeout=lock_timeout
     ) as lock:
-        ACTIVE_LOCKS.add(lock_name)
-        yield lock
-        ACTIVE_LOCKS.remove(lock_name)
-        if gevent:
-            # Needed for django-db-geventpool
-            close_gevent_db_connection()
+        try:
+            ACTIVE_LOCKS.add(lock_name)
+            yield lock
+            ACTIVE_LOCKS.remove(lock_name)
+        finally:
+            if gevent:
+                # Needed for django-db-geventpool
+                close_gevent_db_connection()


### PR DESCRIPTION
### What was wrong?

Reindexing of missing transactions were overloading the service

### How was it fixed?
- Only one reindexing is allowed at a time now. It should be enough for quickly fix all the problematic Safes
- Database event pool is always closed, even if an exception occurs
- `safe_transaction_service.history.tasks.process_decoded_internal_txs_task` will only be called every 20 minutes. The task is already called every time a new trace appears either way and the scheduled task is only to make sure everything was processed, so no need to be biminutely