### PR TITLE
Add endpoints for Ethereum RPC info

### DIFF
--- a/safe_transaction_service/history/tests/test_views.py
+++ b/safe_transaction_service/history/tests/test_views.py
@@ -50,6 +50,26 @@ logger = logging.getLogger(__name__)
 
 
 class TestViews(SafeTestCaseMixin, APITestCase):
+    def test_about_view(self):
+        url = reverse("v1:history:about")
+        response = self.client.get(url, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_about_ethereum_rpc_url(self):
+        for url_name in (
+            "v1:history:about-ethereum-rpc",
+            "v1:history:about-ethereum-tracing-rpc",
+        ):
+            with self.subTest(url_name=url_name):
+                url = reverse(url_name)
+                response = self.client.get(url, format="json")
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertIn("EthereumJS TestRPC", response.data["version"])
+                self.assertGreaterEqual(response.data["block_number"], 0)
+                self.assertEqual(response.data["chain_id"], 1337)
+                self.assertEqual(response.data["chain"], "GANACHE")
+                self.assertEqual(response.data["syncing"], False)
+
     def test_all_transactions_view(self):
         safe_address = Account.create().address
         response = self.client.get(

--- a/safe_transaction_service/history/urls.py
+++ b/safe_transaction_service/history/urls.py
@@ -7,6 +7,16 @@ app_name = "history"
 urlpatterns = [
     path("about/", views.AboutView.as_view(), name="about"),
     path(
+        "about/ethereum-rpc/",
+        views.AboutEthereumRPCView.as_view(),
+        name="about-ethereum-rpc",
+    ),
+    path(
+        "about/ethereum-tracing-rpc/",
+        views.AboutEthereumTracingRPCView.as_view(),
+        name="about-ethereum-tracing-rpc",
+    ),
+    path(
         "about/master-copies/", views.MasterCopiesView.as_view(), name="master-copies"
     ),
     path(


### PR DESCRIPTION
# Endpoints
- `/about/ethereum-rpc/`
- `/about/ethereum-tracing-rpc/`

# Result
```json
{
    "version": "EthereumJS TestRPC/v2.13.2/ethereum-js",
    "block_number": 70,
    "chain_id": 1337,
    "chain": "GANACHE",
    "syncing": false
}
```