### PR TITLE
Read ALLOWED_HOSTS from env for local enviroment

### DIFF
--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -13,7 +13,7 @@ SECRET_KEY = env(
     default="aHdCBMHXuxIxEhfRGFRp7Cp3N9CqEZEEAvwZVlBCazKExkEnzvVs4bYWC8Qqh9lg",
 )
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
-allowed_hosts = env("DJANGO_ALLOWED_HOSTS", default="localhost,0.0.0.0,127.0.0.1,*")
+allowed_hosts = env("DJANGO_ALLOWED_HOSTS", default=".localhost,127.0.0.1,[::1]")
 ALLOWED_HOSTS = [allowed_host.strip() for allowed_host in allowed_hosts.split(",")]
 
 # CACHES

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -1,5 +1,5 @@
 import socket
-
+import os
 from .base import *  # noqa
 from .base import env
 
@@ -13,11 +13,8 @@ SECRET_KEY = env(
     default="aHdCBMHXuxIxEhfRGFRp7Cp3N9CqEZEEAvwZVlBCazKExkEnzvVs4bYWC8Qqh9lg",
 )
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = [
-    "localhost",
-    "0.0.0.0",
-    "127.0.0.1",
-]
+allowed_hosts = os.getenv("DJANGO_ALLOWED_HOSTS", "localhost,0.0.0.0,127.0.0.1,*")
+ALLOWED_HOSTS = [allowed_host.strip() for allowed_host in allowed_hosts.split(",")]
 
 # CACHES
 # ------------------------------------------------------------------------------

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -1,5 +1,5 @@
 import socket
-import os
+
 from .base import *  # noqa
 from .base import env
 
@@ -13,7 +13,7 @@ SECRET_KEY = env(
     default="aHdCBMHXuxIxEhfRGFRp7Cp3N9CqEZEEAvwZVlBCazKExkEnzvVs4bYWC8Qqh9lg",
 )
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
-allowed_hosts = os.getenv("DJANGO_ALLOWED_HOSTS", "localhost,0.0.0.0,127.0.0.1,*")
+allowed_hosts = env("DJANGO_ALLOWED_HOSTS", default="localhost,0.0.0.0,127.0.0.1,*")
 ALLOWED_HOSTS = [allowed_host.strip() for allowed_host in allowed_hosts.split(",")]
 
 # CACHES


### PR DESCRIPTION
### What was wrong?
If a docker compose setup is used for all needed services supporting Gnosis Safe, the transaction service would reject requests coming from other hosts.
Closes #

### How was it fixed?
Flexible `DJANGO_ALLOWED_HOSTS`
@gnosis/safe-services
