### PR TITLE
Bump gnosis-py from 3.7.2 to 3.7.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ docutils==0.18.1
 drf-yasg[validation]==1.20.0
 ethereum==2.3.2
 firebase-admin==5.1.0
-gnosis-py[django]==3.7.2
+gnosis-py[django]==3.7.4
 gunicorn[gevent]==20.1.0
 hexbytes==0.2.2
 packaging>=21.0

--- a/safe_transaction_service/__init__.py
+++ b/safe_transaction_service/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.4.15"
+__version__ = "3.4.16"
 __version_info__ = tuple(
     [
         int(num) if num.isdigit() else num


### PR DESCRIPTION
- Bump gnosis-py from 3.7.2 to 3.7.4 – https://github.com/gnosis/gnosis-py/compare/v3.7.2...v3.7.4 – this includes the fix to the `mulitcall2` address for `Avalanche`
- Bump service version from 3.4.15 to 3.4.16