### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence.
-* @uxio0 @fmrsabino
+* @gnosis/safe-services


### PR DESCRIPTION
- Use `@gnosis/safe-services` for `CODEOWNERS` instead of individual contributors