### PR TITLE
flexible allowed hosts for docker compose

### DIFF
--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -13,11 +13,9 @@ SECRET_KEY = env(
     default="aHdCBMHXuxIxEhfRGFRp7Cp3N9CqEZEEAvwZVlBCazKExkEnzvVs4bYWC8Qqh9lg",
 )
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = [
-    "localhost",
-    "0.0.0.0",
-    "127.0.0.1",
-]
+ALLOWED_HOSTS = env.list(
+    "DJANGO_ALLOWED_HOSTS", default=[".localhost", "127.0.0.1", "[::1]"]
+)
 
 # CACHES
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
What was wrong?
If a docker compose setup is used for all needed services supporting Gnosis Safe, the transaction service would reject requests coming from other hosts.
Closes #

How was it fixed?
Flexible DJANGO_ALLOWED_HOSTS
@gnosis/safe-services


https://github.com/gnosis/safe-transaction-service/pull/530