### PR TITLE
Fix token migration

### DIFF
--- a/safe_transaction_service/tokens/migrations/0004_ethereum_address_field_v2_20211201_1512.py
+++ b/safe_transaction_service/tokens/migrations/0004_ethereum_address_field_v2_20211201_1512.py
@@ -13,7 +13,10 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL(
-            "DROP INDEX IF EXISTS tokens_token_address_18ef94ca_like",
+            """
+            DROP INDEX IF EXISTS tokens_token_address_18ef94ca_like;
+            ALTER TABLE "tokens_token" ALTER COLUMN "address" TYPE bytea USING DECODE(SUBSTRING("address", 3), 'hex');
+            """,
             reverse_sql=migrations.RunSQL.noop,
         ),
         migrations.AlterField(


### PR DESCRIPTION
### What was wrong?

Token address migration was only casting `varchar` instead of converting to `bytea`
