### PR TITLE
Fix celery concurrency

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -206,6 +206,10 @@ INSTALLED_APPS += [
 ]
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-broker_url
 CELERY_BROKER_URL = env("CELERY_BROKER_URL", default="django://")
+# https://docs.celeryproject.org/en/stable/userguide/optimizing.html#broker-connection-pools
+CELERY_BROKER_POOL_LIMIT = env(
+    "CELERY_BROKER_POOL_LIMIT", default=env("CELERYD_CONCURRENCY", default=500)
+)
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-result_backend
 if CELERY_BROKER_URL == "django://":
     CELERY_RESULT_BACKEND = "redis://"

--- a/docker/web/celery/worker/run.sh
+++ b/docker/web/celery/worker/run.sh
@@ -16,4 +16,4 @@ echo "==> $(date +%H:%M:%S) ==> Setting up service... "
 python manage.py setup_service
 
 echo "==> $(date +%H:%M:%S) ==> Running Celery worker <=="
-exec celery -A config.celery_app worker --loglevel $log_level --pool=gevent --concurrency=120
+exec celery -A config.celery_app worker --loglevel $log_level --pool=gevent --concurrency=${CELERYD_CONCURRENCY:-500}

--- a/safe_transaction_service/__init__.py
+++ b/safe_transaction_service/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.4.17"
+__version__ = "3.4.18"
 __version_info__ = tuple(
     [
         int(num) if num.isdigit() else num


### PR DESCRIPTION
### What was wrong?

- Concurrency was too low (`120`) to process all the needed tasks. A higher number can be used as we are using `gevent` (light threads)

### How was it fixed?

- Make concurrency configurable so we can adjust it without a deployment
- Set `500` as a default for concurrency (x5)
- Increase `CELERY_BROKER_POOL_LIMIT` as stated here: https://docs.celeryproject.org/en/stable/userguide/optimizing.html#broker-connection-pools



@gnosis/safe-services
