### PR TITLE
Updated issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,10 +13,19 @@ A clear and concise description of what the bug is.
 **To Reproduce**
 Steps to reproduce the behavior:
 1. Do POST on '...'
+  - Provide `json` you are submitting to the service (if it applies)
 2. Then GET on '....'
+3. Links to issues in other repos (if possible)
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
+
+**Environment (please complete the following information):**
+ - Staging or production?
+ - Which chain?
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -14,7 +14,10 @@ A clear and concise description of what you want to happen.
 More information about the feature needed
 
 # Related issues
-Paste here the related links for the issues on the clients/safe project if applicable
+Paste here the related links for the issues on the clients/safe project if applicable. Please provide at least one of the following:
+- Links to epics in your repository
+- Images taken from mocks
+- Gitbook or any form of written documentation links, etc. Any of these alternatives will help us contextualise your request.
 
 # Endpoint
 If applicable, description on the endpoint and the result you expect:


### PR DESCRIPTION
### What was wrong?

Included more explicit requests of context for features and bugs
Closes #(there is no associated issue in this repo)

### How was it fixed?
Added similar instructions to what's available in the `safe-config-service` and the `safe-client-gateway`

@gnosis/safe-services
