### PR TITLE
Fix native coin price on token fiat endpoint

### DIFF
--- a/safe_transaction_service/history/services/balance_service.py
+++ b/safe_transaction_service/history/services/balance_service.py
@@ -253,7 +253,7 @@ class BalanceService:
             safe_address, only_trusted, exclude_spam
         )
         try:
-            eth_price = self.price_service.get_eth_usd_price()
+            eth_price = self.price_service.get_native_coin_usd_price()
         except CannotGetPrice:
             logger.warning("Cannot get network ether price", exc_info=True)
             eth_price = 0

--- a/safe_transaction_service/history/tests/clients/test_ens_client.py
+++ b/safe_transaction_service/history/tests/clients/test_ens_client.py
@@ -34,7 +34,7 @@ class TestEnsClient(TestCase):
                 "registrations": [
                     {
                         "domain": {
-                            "isMigrated": False,
+                            "isMigrated": True,
                             "labelName": "vivarox",
                             "labelhash": "0x3dad4bca5efcde980e9e7f3a9484749505648542b06c5f4f8b2dbdb767f67ba8",
                             "name": "vivarox.eth",
@@ -44,7 +44,7 @@ class TestEnsClient(TestCase):
                     },
                     {
                         "domain": {
-                            "isMigrated": False,
+                            "isMigrated": True,
                             "labelName": "satoshinakamoto",
                             "labelhash": "0x595165e57d0d5a26f71f2f387c9e8208831fa957a18aad079218ce42a530bc6e",
                             "name": "satoshinakamoto.eth",
@@ -54,7 +54,7 @@ class TestEnsClient(TestCase):
                     },
                     {
                         "domain": {
-                            "isMigrated": False,
+                            "isMigrated": True,
                             "labelName": "vitalik",
                             "labelhash": "0xaf2caa1c2ca1d027f1ac823b529d0a67cd144264b2789fa2ea4d63a67c7103cc",
                             "name": "vitalik.eth",

--- a/safe_transaction_service/history/tests/test_balance_service.py
+++ b/safe_transaction_service/history/tests/test_balance_service.py
@@ -38,13 +38,13 @@ class TestBalanceService(EthereumTestCaseMixin, TestCase):
         PriceService, "get_token_eth_value", return_value=0.4, autospec=True
     )
     @mock.patch.object(
-        PriceService, "get_eth_usd_price", return_value=123.4, autospec=True
+        PriceService, "get_native_coin_usd_price", return_value=123.4, autospec=True
     )
     @mock.patch.object(timezone, "now", return_value=timezone.now())
     def test_get_usd_balances(
         self,
         timezone_now_mock: MagicMock,
-        get_eth_usd_price_mock: MagicMock,
+        get_native_coin_usd_price_mock: MagicMock,
         get_token_eth_value_mock: MagicMock,
     ):
         balance_service = BalanceServiceProvider()

--- a/safe_transaction_service/history/tests/test_views.py
+++ b/safe_transaction_service/history/tests/test_views.py
@@ -1308,13 +1308,13 @@ class TestViews(SafeTestCaseMixin, APITestCase):
         PriceService, "get_token_eth_value", return_value=0.4, autospec=True
     )
     @mock.patch.object(
-        PriceService, "get_eth_usd_price", return_value=123.4, autospec=True
+        PriceService, "get_native_coin_usd_price", return_value=123.4, autospec=True
     )
     @mock.patch.object(timezone, "now", return_value=timezone.now())
     def test_safe_balances_usd_view(
         self,
         timezone_now_mock: MagicMock,
-        get_eth_usd_price_mock: MagicMock,
+        get_native_coin_usd_price_mock: MagicMock,
         get_token_eth_value_mock: MagicMock,
         get_token_info_mock: MagicMock,
     ):

--- a/safe_transaction_service/tokens/services/price_service.py
+++ b/safe_transaction_service/tokens/services/price_service.py
@@ -172,9 +172,9 @@ class PriceService:
 
     @cachedmethod(cache=operator.attrgetter("cache_eth_price"))
     @cache_memoize(60 * 30, prefix="balances-get_eth_usd_price")  # 30 minutes
-    def get_eth_usd_price(self) -> float:
+    def get_native_coin_usd_price(self) -> float:
         """
-        Get USD price for Ether. It depends on the ethereum network:
+        Get USD price for native coin. It depends on the ethereum network:
             - On mainnet, use ETH/USD
             - On xDAI, use DAI/USD.
             - On EWT/VOLTA, use EWT/USD
@@ -321,7 +321,7 @@ class PriceService:
         :return: eth prices with timestamp if ready on cache, `0.` and None otherwise
         """
         try:
-            eth_price = self.get_eth_usd_price()
+            eth_price = self.get_native_coin_usd_price()
         except CannotGetPrice:
             logger.warning("Cannot get network ether price", exc_info=True)
             eth_price = 0

--- a/safe_transaction_service/tokens/tasks.py
+++ b/safe_transaction_service/tokens/tasks.py
@@ -65,7 +65,7 @@ def calculate_token_eth_price_task(
         eth_price = (
             price_service.get_token_eth_value(token_address)
             or price_service.get_token_usd_price(token_address)
-            / price_service.get_eth_usd_price()
+            / price_service.get_native_coin_usd_price()
         )
         if not eth_price:  # Try composed oracles
             if underlying_tokens := price_service.get_underlying_tokens(token_address):

--- a/safe_transaction_service/tokens/tests/test_views.py
+++ b/safe_transaction_service/tokens/tests/test_views.py
@@ -155,7 +155,12 @@ class TestTokenViews(SafeTestCaseMixin, APITestCase):
             )
             self.assertTrue(response.data["timestamp"])
 
-    def test_token_price_view_address_0(self):
+    @mock.patch.object(
+        PriceService, "get_native_coin_usd_price", return_value=321.2, autospec=True
+    )
+    def test_token_price_view_address_0(
+        self, get_native_coin_usd_price_mock: MagicMock
+    ):
         token_address = "0x0000000000000000000000000000000000000000"
 
         response = self.client.get(
@@ -165,5 +170,5 @@ class TestTokenViews(SafeTestCaseMixin, APITestCase):
         # Native token should be retrieved even if it is not part of the Token table
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["fiat_code"], "USD")
-        self.assertTrue(response.data["fiat_price"])
+        self.assertEqual(response.data["fiat_price"], "321.2")
         self.assertTrue(response.data["timestamp"])


### PR DESCRIPTION
- When providing `0x00.00` on `tokens/<address>/prices/usd/ fiat value for the native coin was not retrieved