### PR TITLE
Use psycopg2 instead of psycopg2-binary

### DIFF
--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -9,6 +9,7 @@ RUN set -ex \
 	&& buildDeps=" \
 		build-essential \
 		libssl-dev \
+        libpq-dev \
 		" \
     && apt-get update \
     && apt-get install -y --no-install-recommends $buildDeps tmux postgresql-client \

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ hexbytes==0.2.2
 packaging>=21.0
 pillow==8.4.0
 psycogreen==1.0.2
-psycopg2-binary==2.9.2
+psycopg2==2.9.2
 redis==4.0.2
 requests==2.26.0
 web3==5.24.0


### PR DESCRIPTION
https://www.psycopg.org/docs/install.html#psycopg-vs-psycopg-binary