### PR TITLE
Increase number of DB `MAX_CONNS` from 4 -> 50

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -50,10 +50,11 @@ DATABASES = {
 DATABASES["default"]["ATOMIC_REQUESTS"] = False
 DATABASES["default"]["ENGINE"] = "django_db_geventpool.backends.postgresql_psycopg2"
 DATABASES["default"]["CONN_MAX_AGE"] = 0
+DB_MAX_CONNS = env.int("DB_MAX_CONNS", default=50)
 DATABASES["default"]["OPTIONS"] = {
     # https://github.com/jneight/django-db-geventpool#settings
-    "MAX_CONNS": 4,
-    "REUSE_CONNS": 4,
+    "MAX_CONNS": DB_MAX_CONNS,
+    "REUSE_CONNS": env.int("DB_REUSE_CONNS", default=DB_MAX_CONNS),
 }
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"


### PR DESCRIPTION
### What was wrong?

- There were deadlocks on DB access (detected on production xDai)
- Number of max connections to the database was reduced to `4` when there were performance issues on DB level, so DB woulnd't get overloaded. Now we can safetely increase it again.

### How was it fixed?

- Increase number of DB `MAX_CONNS` from 4 -> 50
- A task was not closing DB connections, it was fixed
- `MAX_CONNS` and `REUSE_CONNS` are now configurable via environment var
