### PR TITLE
Remove serializer validation when ENABLE_OWNERS_ENDPOINT is false

### DIFF
--- a/safe_transaction_service/__init__.py
+++ b/safe_transaction_service/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.4.23"
+__version__ = "3.4.24"
 __version_info__ = tuple(
     [
         int(num) if num.isdigit() else num

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -1042,6 +1042,7 @@ class OwnersView(APIView):
 
     def get_owners_empty(self):
         serializer = self.serializer_class(data={"safes": []})
+        assert serializer.is_valid()
         return Response(status=status.HTTP_200_OK, data=serializer.data)
 
 


### PR DESCRIPTION
### What was wrong?

- When using a serialiser we should call `.is_valid()` before accessing it via `Response`
