### PR TITLE
Require token auth for OwnersView

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,29 @@ A user must be created to get access:
 docker exec -it safe-transaction-service_web_1 python manage.py createsuperuser
 ```
 
+## Authenticated Endpoints
+
+Currently most public endpoints do not have any authentication in place. However some endpoiints do require authentication in order to be used such as `/api/v1/owners/<str:address>/safes/`. For accessing such endpoints a token needs to be created (which will be associated to a specific user).
+
+### 1. Create an authorization token:
+
+1a. This can be done via the admin interface under `/admin/authtoken/tokenproxy/`
+
+OR
+
+1b. By using the following command:
+
+```shell
+python manage.py drf_create_token <username>
+```
+
+### 2. Use the generated token to access authenticated endpoints:
+
+
+```shell
+curl -X GET "http://127.0.0.1:8000/api/v1/owners/<str:address>/safes/" -H 'Authorization: Token <auth_token>'
+```
+
 ## Safe Contract ABIs and addresses
 - [v1.3.0](https://github.com/gnosis/safe-deployments/blob/main/src/assets/v1.3.0/gnosis_safe.json)
 - [v1.3.0 L2](https://github.com/gnosis/safe-deployments/blob/main/src/assets/v1.3.0/gnosis_safe_l2.json)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -420,3 +420,9 @@ AWS_CONFIGURED = bool(
 
 ETHERSCAN_API_KEY = env("ETHERSCAN_API_KEY", default=None)
 IPFS_GATEWAY = env("IPFS_GATEWAY", default="https://cloudflare-ipfs.com/")
+
+SWAGGER_SETTINGS = {
+    "SECURITY_DEFINITIONS": {
+        "api_key": {"type": "apiKey", "in": "header", "name": "Authorization"}
+    },
+}

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -83,6 +83,7 @@ THIRD_PARTY_APPS = [
     "rest_framework",
     "drf_yasg",
     "django_s3_storage",
+    "rest_framework.authtoken",
 ]
 LOCAL_APPS = [
     "safe_transaction_service.contracts.apps.ContractsConfig",
@@ -419,4 +420,3 @@ AWS_CONFIGURED = bool(
 
 ETHERSCAN_API_KEY = env("ETHERSCAN_API_KEY", default=None)
 IPFS_GATEWAY = env("IPFS_GATEWAY", default="https://cloudflare-ipfs.com/")
-ENABLE_OWNERS_ENDPOINT = env.bool("ENABLE_OWNERS_ENDPOINT", default=True)

--- a/safe_transaction_service/__init__.py
+++ b/safe_transaction_service/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.4.24"
+__version__ = "3.4.25"
 __version_info__ = tuple(
     [
         int(num) if num.isdigit() else num

--- a/safe_transaction_service/history/admin.py
+++ b/safe_transaction_service/history/admin.py
@@ -6,6 +6,7 @@ from django.db.models.functions import Greatest
 from django.db.transaction import atomic
 
 from hexbytes import HexBytes
+from rest_framework.authtoken.admin import TokenAdmin
 
 from gnosis.eth import EthereumClientProvider
 
@@ -27,6 +28,14 @@ from .models import (
     WebHook,
 )
 from .services import IndexServiceProvider
+
+# By default, TokenAdmin doesn't allow key edition
+# IFF you have a service that requests from multiple safe-transaction-service
+# you might want to share that key for convenience between instances.
+TokenAdmin.fields = (
+    "user",
+    "key",
+)
 
 
 # Inline objects ------------------------------

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -11,6 +11,7 @@ import django_filters
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
+from rest_framework.authentication import TokenAuthentication
 from rest_framework.filters import OrderingFilter
 from rest_framework.generics import (
     DestroyAPIView,
@@ -20,6 +21,7 @@ from rest_framework.generics import (
     RetrieveAPIView,
     get_object_or_404,
 )
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -1006,6 +1008,8 @@ class MasterCopiesView(ListAPIView):
 
 
 class OwnersView(APIView):
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
     serializer_class = serializers.OwnerResponseSerializer
 
     @swagger_auto_schema(
@@ -1029,19 +1033,8 @@ class OwnersView(APIView):
                 },
             )
 
-        if settings.ENABLE_OWNERS_ENDPOINT:
-            return self.get_owners(address)
-        else:
-            return self.get_owners_empty()
-
-    def get_owners(self, address):
         safes_for_owner = SafeStatus.objects.addresses_for_owner(address)
         serializer = self.serializer_class(data={"safes": safes_for_owner})
-        assert serializer.is_valid()
-        return Response(status=status.HTTP_200_OK, data=serializer.data)
-
-    def get_owners_empty(self):
-        serializer = self.serializer_class(data={"safes": []})
         assert serializer.is_valid()
         return Response(status=status.HTTP_200_OK, data=serializer.data)
 


### PR DESCRIPTION
- `OwnersView` now requires authentication via a `Token`
- This `Token` should be set for users who want to access this endpoint (this can be done via the admin interface)
- Given a valid token `example-token`, the token can be used by adding the following header to the request for this endpoint: `Authorization: Token example-token`
- Unauthenticated requests return a `401`
- Reverted changes made for releases `3.4.22`, `3.4.23` and `3.4.24`. For comparison this is the diff between `3.4.21` and the upcoming release https://github.com/gnosis/safe-transaction-service/compare/v3.4.21...use-token-auth