### PR TITLE
Disable IgnoreSucceededNone filter

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -264,9 +264,6 @@ LOGGING = {
     "disable_existing_loggers": False,
     "filters": {
         "require_debug_false": {"()": "django.utils.log.RequireDebugFalse"},
-        "ignore_succeeded_none": {
-            "()": "safe_transaction_service.utils.loggers.IgnoreSucceededNone"
-        },
     },
     "formatters": {
         "short": {"format": "%(asctime)s %(message)s"},
@@ -296,7 +293,6 @@ LOGGING = {
         },
         "celery_console": {
             "level": "DEBUG",
-            "filters": ["ignore_succeeded_none"],
             "class": "logging.StreamHandler",
             "formatter": "celery_verbose",
         },

--- a/safe_transaction_service/utils/tests/test_loggers.py
+++ b/safe_transaction_service/utils/tests/test_loggers.py
@@ -2,6 +2,8 @@ from logging import LogRecord
 
 from django.test import TestCase
 
+import pytest
+
 from ..loggers import IgnoreCheckUrl, IgnoreSucceededNone
 
 
@@ -21,6 +23,7 @@ class TestLoggers(TestCase):
         self.assertFalse(ignore_check_url.filter(check_log))
         self.assertTrue(ignore_check_url.filter(other_log))
 
+    @pytest.mark.skip(reason="Filter is disabled temporarily")  # TODO
     def test_ignore_succeeded_none(self):
         name = "name"
         level = 1


### PR DESCRIPTION
- In order to collect more data on the tasks' execution, the `IgnoreSucceededNone` filter should be disabled

(We will be testing this on staging before making a decision if this should be pushed to production or be behind an additional runtime configuration parameter)