### PR TITLE
Disable authentication in OwnersView

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,29 +141,6 @@ A user must be created to get access:
 docker exec -it safe-transaction-service_web_1 python manage.py createsuperuser
 ```
 
-## Authenticated Endpoints
-
-Currently most public endpoints do not have any authentication in place. However some endpoiints do require authentication in order to be used such as `/api/v1/owners/<str:address>/safes/`. For accessing such endpoints a token needs to be created (which will be associated to a specific user).
-
-### 1. Create an authorization token:
-
-1a. This can be done via the admin interface under `/admin/authtoken/tokenproxy/`
-
-OR
-
-1b. By using the following command:
-
-```shell
-python manage.py drf_create_token <username>
-```
-
-### 2. Use the generated token to access authenticated endpoints:
-
-
-```shell
-curl -X GET "http://127.0.0.1:8000/api/v1/owners/<str:address>/safes/" -H 'Authorization: Token <auth_token>'
-```
-
 ## Safe Contract ABIs and addresses
 - [v1.3.0](https://github.com/gnosis/safe-deployments/blob/main/src/assets/v1.3.0/gnosis_safe.json)
 - [v1.3.0 L2](https://github.com/gnosis/safe-deployments/blob/main/src/assets/v1.3.0/gnosis_safe_l2.json)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -420,3 +420,9 @@ AWS_CONFIGURED = bool(
 
 ETHERSCAN_API_KEY = env("ETHERSCAN_API_KEY", default=None)
 IPFS_GATEWAY = env("IPFS_GATEWAY", default="https://cloudflare-ipfs.com/")
+
+SWAGGER_SETTINGS = {
+    "SECURITY_DEFINITIONS": {
+        "api_key": {"type": "apiKey", "in": "header", "name": "Authorization"}
+    },
+}

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -420,9 +420,3 @@ AWS_CONFIGURED = bool(
 
 ETHERSCAN_API_KEY = env("ETHERSCAN_API_KEY", default=None)
 IPFS_GATEWAY = env("IPFS_GATEWAY", default="https://cloudflare-ipfs.com/")
-
-SWAGGER_SETTINGS = {
-    "SECURITY_DEFINITIONS": {
-        "api_key": {"type": "apiKey", "in": "header", "name": "Authorization"}
-    },
-}

--- a/safe_transaction_service/history/tests/test_views.py
+++ b/safe_transaction_service/history/tests/test_views.py
@@ -333,8 +333,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             + "?transaction_hash=0x2345"
         )
         response = self.client.get(url, format="json")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["count"], 0)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         url = (
             reverse("v1:history:module-transactions", args=(safe_address,))
@@ -2227,8 +2226,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             + "?transaction_hash=0x2345"
         )
         response = self.client.get(url, format="json")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["count"], 0)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         # Add from tx
         internal_tx_2 = InternalTxFactory(_from=safe_address, value=value)

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -11,7 +11,6 @@ import django_filters
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
-from rest_framework.authentication import TokenAuthentication
 from rest_framework.filters import OrderingFilter
 from rest_framework.generics import (
     DestroyAPIView,
@@ -21,7 +20,6 @@ from rest_framework.generics import (
     RetrieveAPIView,
     get_object_or_404,
 )
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -1008,8 +1006,6 @@ class MasterCopiesView(ListAPIView):
 
 
 class OwnersView(APIView):
-    authentication_classes = [TokenAuthentication]
-    permission_classes = [IsAuthenticated]
     serializer_class = serializers.OwnerResponseSerializer
 
     @swagger_auto_schema(


### PR DESCRIPTION
- `OwnersView` no longer requires authentication
- Tokens can still be created as before (the API token feature was not removed)