### PR TITLE
Set low priority for webhook/notification tasks

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -229,7 +229,10 @@ CELERY_IGNORE_RESULT = True
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-task_always_eager
 CELERY_ALWAYS_EAGER = False
 # https://docs.celeryproject.org/en/latest/userguide/configuration.html#task-default-priority
-CELERY_TASK_DEFAULT_PRIORITY = 5  # Higher = more priority
+# Higher = more priority on RabbitMQ, opposite on Redis ¯\_(ツ)_/¯
+CELERY_TASK_DEFAULT_PRIORITY = 3
+# https://docs.celeryproject.org/en/stable/userguide/configuration.html#task-queue-max-priority
+CELERY_TASK_QUEUE_MAX_PRIORITY = 10
 # https://docs.celeryproject.org/en/latest/userguide/configuration.html#broker-transport-options
 CELERY_BROKER_TRANSPORT_OPTIONS = {
     "queue_order_strategy": "priority",

--- a/safe_transaction_service/contracts/tasks.py
+++ b/safe_transaction_service/contracts/tasks.py
@@ -36,7 +36,7 @@ def create_missing_contracts_with_metadata_task() -> int:
     for address in addresses:
         logger.info("Detected missing contract %s", address)
         create_or_update_contract_with_metadata_task.apply_async(
-            (address,), priority=0
+            (address,), priority=5
         )  # Lowest priority
         i += 1
     return i
@@ -55,7 +55,7 @@ def reindex_contracts_without_metadata_task() -> int:
         Contract.objects.without_metadata().values_list("address", flat=True).iterator()
     ):
         logger.info("Reindexing contract %s", address)
-        create_or_update_contract_with_metadata_task.apply_async((address,), priority=0)
+        create_or_update_contract_with_metadata_task.apply_async((address,), priority=5)
         i += 1
     return i
 

--- a/safe_transaction_service/history/signals.py
+++ b/safe_transaction_service/history/signals.py
@@ -247,9 +247,13 @@ def process_webhook(
     )
     for payload in payloads:
         if address := payload.get("address"):
-            send_webhook_task.delay(address, payload)
+            send_webhook_task.apply_async(
+                args=(address, payload), priority=4
+            )  # Almost the lowest priority
             if is_relevant_notification(sender, instance, created):
-                send_notification_task.apply_async(args=(address, payload), countdown=5)
+                send_notification_task.apply_async(
+                    args=(address, payload), countdown=5, priority=4
+                )
             else:
                 logger.debug(
                     "Notification will not be sent for created=%s object=%s",

--- a/safe_transaction_service/history/tests/test_signals.py
+++ b/safe_transaction_service/history/tests/test_signals.py
@@ -79,7 +79,7 @@ class TestSignals(TestCase):
     @factory.django.mute_signals(post_save)
     def test_process_webhook(self):
         multisig_confirmation = MultisigConfirmationFactory()
-        with mock.patch.object(send_webhook_task, "delay") as webhook_task_mock:
+        with mock.patch.object(send_webhook_task, "apply_async") as webhook_task_mock:
             with mock.patch.object(
                 send_notification_task, "apply_async"
             ) as send_notification_task_mock:
@@ -88,7 +88,7 @@ class TestSignals(TestCase):
                 send_notification_task_mock.assert_called()
 
         multisig_confirmation.created -= timedelta(minutes=45)
-        with mock.patch.object(send_webhook_task, "delay") as webhook_task_mock:
+        with mock.patch.object(send_webhook_task, "apply_async") as webhook_task_mock:
             with mock.patch.object(
                 send_notification_task, "apply_async"
             ) as send_notification_task_mock:


### PR DESCRIPTION
Regular priority for Celery is 3, we are setting 1 for these tasks (the lowest the less priority)

This is a first fix for #620