### PR TITLE
Normalize IPFS addresses when using HTTP gateway

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -419,7 +419,7 @@ AWS_CONFIGURED = bool(
 )
 
 ETHERSCAN_API_KEY = env("ETHERSCAN_API_KEY", default=None)
-IPFS_GATEWAY = env("IPFS_GATEWAY", default="https://cloudflare-ipfs.com/")
+IPFS_GATEWAY = env("IPFS_GATEWAY", default="https://cloudflare-ipfs.com/ipfs/")
 
 SWAGGER_SETTINGS = {
     "SECURITY_DEFINITIONS": {

--- a/safe_transaction_service/history/services/collectibles_service.py
+++ b/safe_transaction_service/history/services/collectibles_service.py
@@ -41,6 +41,7 @@ class MetadataRetrievalException(CollectiblesServiceException):
 
 def ipfs_to_http(uri: Optional[str]) -> Optional[str]:
     if uri and uri.startswith("ipfs://"):
+        uri = uri.replace("ipfs://ipfs/", "ipfs://")
         return urljoin(
             settings.IPFS_GATEWAY, uri.replace("ipfs://", "", 1)
         )  # Use ipfs gateway
@@ -159,6 +160,7 @@ class CollectiblesService:
         """
         Get metadata from uri. Maybe at some point support IPFS or another protocols. Currently just http/https is
         supported
+
         :param uri: Uri starting with the protocol, like http://example.org/token/3
         :return: Metadata as a decoded json
         """

--- a/safe_transaction_service/history/tests/test_collectibles_service.py
+++ b/safe_transaction_service/history/tests/test_collectibles_service.py
@@ -38,7 +38,13 @@ class TestCollectiblesService(EthereumTestCaseMixin, TestCase):
         ipfs_url = "ipfs://testing-url/path/?arguments"
         result = ipfs_to_http(ipfs_url)
         self.assertTrue(result.startswith("http"))
-        self.assertIn("testing-url/path/?arguments", result)
+        self.assertIn("ipfs/testing-url/path/?arguments", result)
+
+        ipfs_with_path_url = "ipfs://ipfs/testing-url/path/?arguments"
+        result = ipfs_to_http(ipfs_with_path_url)
+        self.assertTrue(result.startswith("http"))
+        self.assertNotIn("ipfs/ipfs", result)
+        self.assertIn("ipfs/testing-url/path/?arguments", result)
 
     def test_get_collectibles(self):
         mainnet_node = just_test_if_mainnet_node()


### PR DESCRIPTION
Ipfs addresses can be ipfs://hash or ipfs://ipfs/hash. Both ways will be converted to the same http url