### PR TITLE
Fix parsing when Token name/symbol are bytes

### DIFF
--- a/safe_transaction_service/tokens/models.py
+++ b/safe_transaction_service/tokens/models.py
@@ -94,6 +94,13 @@ class TokenManager(models.Manager):
 
         # If symbol is way bigger than name (by 5 characters), swap them (e.g. POAP)
         name, symbol = erc_info.name, erc_info.symbol
+
+        if name is bytes:
+            name = name.decode("utf-8", errors="replace").replace("\x00", "\uFFFD")
+
+        if symbol is bytes:
+            symbol = symbol.decode("utf-8", errors="replace").replace("\x00", "\uFFFD")
+
         if (len(name) - len(symbol)) < -5:
             name, symbol = symbol, name
         return self.create(

--- a/safe_transaction_service/tokens/models.py
+++ b/safe_transaction_service/tokens/models.py
@@ -95,10 +95,10 @@ class TokenManager(models.Manager):
         # If symbol is way bigger than name (by 5 characters), swap them (e.g. POAP)
         name, symbol = erc_info.name, erc_info.symbol
 
-        if name is bytes:
+        if isinstance(name, bytes):
             name = name.decode("utf-8", errors="replace").replace("\x00", "\uFFFD")
 
-        if symbol is bytes:
+        if isinstance(symbol, bytes):
             symbol = symbol.decode("utf-8", errors="replace").replace("\x00", "\uFFFD")
 
         if (len(name) - len(symbol)) < -5:

--- a/safe_transaction_service/tokens/tests/test_models.py
+++ b/safe_transaction_service/tokens/tests/test_models.py
@@ -126,3 +126,24 @@ class TestModels(TestCase):
         self.assertEqual(
             token.name, "Balancer Pool Token " + get_metadata_mock.return_value.name
         )
+
+    from gnosis.eth.ethereum_client import Erc20Info, Erc20Manager
+
+    @mock.patch.object(
+        Erc20Manager,
+        "get_info",
+        autospec=True,
+        return_value=Erc20Info(
+            name=b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01",
+            symbol=b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01",
+            decimals=18,
+        ),
+    )
+    def test_create_from_blockchain_with_byte_data(self, get_info: MagicMock):
+        Token.objects.create_from_blockchain(
+            "0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413"
+        )
+
+        token = Token.objects.get(address="0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413")
+        self.assertEqual(token.name, "�������������������������������\x01")
+        self.assertEqual(token.symbol, "�������������������������������\x01")

--- a/safe_transaction_service/tokens/tests/test_models.py
+++ b/safe_transaction_service/tokens/tests/test_models.py
@@ -6,6 +6,8 @@ from django.test import TestCase
 
 from eth_account import Account
 
+from gnosis.eth.ethereum_client import Erc20Info, Erc20Manager
+
 from ..clients.zerion_client import (
     BalancerTokenAdapterClient,
     ZerionPoolMetadata,
@@ -126,8 +128,6 @@ class TestModels(TestCase):
         self.assertEqual(
             token.name, "Balancer Pool Token " + get_metadata_mock.return_value.name
         )
-
-    from gnosis.eth.ethereum_client import Erc20Info, Erc20Manager
 
     @mock.patch.object(
         Erc20Manager,


### PR DESCRIPTION
### What was wrong?

Closes #626 

### How was it fixed?

- `name` and `symbol` can either be a `str` or `bytes`. If it happens to be `bytes` (as it happens with the the token `0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413`) then the trimming of the `name` and/or `symbol` will not work and a DB constraint exception is thrown – `django.db.utils.DataError: value too long for type character varying(60)`
- Additionally, if `bytes` is correctly converted into a `str`, `bytes` might contain `NULL` characters (`\x00`) which are not valid for under DB constraints (for `name` and `symbol`)
- Therefore `NULL` characters are replaced by �. More specifically for the token `0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413`:

```
name: b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
symbol: b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
```

would be saved as 

```
name: �������������������������������\x01
symbol: �������������������������������\x01
```
