### PR TITLE
Show queries to ethereum nodes when enabling DEBUG

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -310,6 +310,9 @@ LOGGING = {
             "handlers": ["console"],
             "level": "INFO",
         },
+        "web3.providers": {
+            "level": "DEBUG" if DEBUG else "WARNING",
+        },
         "django.geventpool": {
             "level": "DEBUG" if DEBUG else "WARNING",
         },


### PR DESCRIPTION
### What was wrong?

- There wasn't a way to see queries/responses to/from ethereum nodes
- Closes #434

### How was it fixed?

- Log queries/responses to/from ethereum nodes
