### PR TITLE
support for trusted csrf origins

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -60,6 +60,12 @@ SECURE_CONTENT_TYPE_NOSNIFF = env.bool(
 SECURE_BROWSER_XSS_FILTER = True
 # https://docs.djangoproject.com/en/dev/ref/settings/#x-frame-options
 X_FRAME_OPTIONS = "DENY"
+# https://docs.djangoproject.com/en/3.2/ref/settings/#csrf-trusted-origins
+allowed_csrf_origins = env("CSRF_TRUSTED_ORIGINS", default="")
+CSRF_TRUSTED_ORIGINS = [
+    allowed_csrf_origins.strip()
+    for allowed_csrf_origins in allowed_csrf_origins.split(",")
+]
 
 # TEMPLATES
 # ------------------------------------------------------------------------------

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -61,11 +61,7 @@ SECURE_BROWSER_XSS_FILTER = True
 # https://docs.djangoproject.com/en/dev/ref/settings/#x-frame-options
 X_FRAME_OPTIONS = "DENY"
 # https://docs.djangoproject.com/en/3.2/ref/settings/#csrf-trusted-origins
-allowed_csrf_origins = env("CSRF_TRUSTED_ORIGINS", default="")
-CSRF_TRUSTED_ORIGINS = [
-    allowed_csrf_origins.strip()
-    for allowed_csrf_origins in allowed_csrf_origins.split(",")
-]
+CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS", default=[""])
 
 # TEMPLATES
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
### What was wrong?
Support for CSRF trusted origins https://docs.djangoproject.com/en/3.2/ref/settings/#csrf-trusted-origins
which is useful for different kinds of deployments.
Relevant: 
https://github.com/gnosis/safe-config-service/pull/402
https://github.com/gnosis/safe-transaction-service/issues/640
Closes #

### How was it fixed?
Added reading env CSRF_TRUSTED_ORIGINS and setting CSRF_TRUSTED_ORIGINS.  
@gnosis/safe-services
