### PR TITLE
Make CSRF_TRUSTED_ORIGINS default [] instead of [""]

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -61,7 +61,7 @@ SECURE_BROWSER_XSS_FILTER = True
 # https://docs.djangoproject.com/en/dev/ref/settings/#x-frame-options
 X_FRAME_OPTIONS = "DENY"
 # https://docs.djangoproject.com/en/3.2/ref/settings/#csrf-trusted-origins
-CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS", default=[""])
+CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS", default=[])
 
 # TEMPLATES
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
- Use Django default https://docs.djangoproject.com/en/4.0/ref/settings/#csrf-trusted-origins