### PR TITLE
Refactor tx decoder

### DIFF
--- a/safe_transaction_service/contracts/tests/test_tx_decoder.py
+++ b/safe_transaction_service/contracts/tests/test_tx_decoder.py
@@ -8,7 +8,10 @@ from web3 import Web3
 from gnosis.eth.constants import NULL_ADDRESS
 from gnosis.safe.multi_send import MultiSendOperation
 
-from safe_transaction_service.contracts.tests.factories import ContractAbiFactory
+from safe_transaction_service.contracts.tests.factories import (
+    ContractAbiFactory,
+    ContractFactory,
+)
 
 from ..tx_decoder import (
     CannotDecode,
@@ -510,19 +513,26 @@ class TestTxDecoder(TestCase):
 
     def test_db_tx_decoder(self):
         example_abi = [
-            {"inputs": [], "stateMutability": "nonpayable", "type": "constructor"},
             {
-                "inputs": [],
-                "name": "uxioSayHi",
-                "outputs": [{"internalType": "address", "name": "", "type": "address"}],
-                "stateMutability": "view",
+                "inputs": [
+                    {"internalType": "uint256", "name": "droidId", "type": "uint256"},
+                    {
+                        "internalType": "uint256",
+                        "name": "numberOfDroids",
+                        "type": "uint256",
+                    },
+                ],
+                "name": "buyDroid",
+                "outputs": [],
+                "stateMutability": "nonpayable",
                 "type": "function",
             },
         ]
+
         example_data = (
             Web3()
             .eth.contract(abi=example_abi)
-            .functions.uxioSayHi()
+            .functions.buyDroid(4, 10)
             .buildTransaction({"gas": 0, "gasPrice": 0, "to": NULL_ADDRESS})["data"]
         )
 
@@ -533,12 +543,39 @@ class TestTxDecoder(TestCase):
         # Test `add_abi`
         db_tx_decoder.add_abi(example_abi)
         fn_name, arguments = db_tx_decoder.decode_transaction(example_data)
-        self.assertEqual(fn_name, "uxioSayHi")
-        self.assertFalse(arguments)
+        self.assertEqual(fn_name, "buyDroid")
+        self.assertEqual(arguments, {"droidId": "4", "numberOfDroids": "10"})
 
         # Test load a new DbTxDecoder
         ContractAbiFactory(abi=example_abi)
         db_tx_decoder = DbTxDecoder()
         fn_name, arguments = db_tx_decoder.decode_transaction(example_data)
-        self.assertEqual(fn_name, "uxioSayHi")
-        self.assertFalse(arguments)
+        self.assertEqual(fn_name, "buyDroid")
+        self.assertEqual(arguments, {"droidId": "4", "numberOfDroids": "10"})
+
+        # Swap ABI parameters
+        swapped_abi = [
+            {
+                "inputs": [
+                    {
+                        "internalType": "uint256",
+                        "name": "numberOfDroids",
+                        "type": "uint256",
+                    },
+                    {"internalType": "uint256", "name": "droidId", "type": "uint256"},
+                ],
+                "name": "buyDroid",
+                "outputs": [],
+                "stateMutability": "nonpayable",
+                "type": "function",
+            },
+        ]
+
+        swapped_contract_abi = ContractAbiFactory(abi=swapped_abi)
+        contract = ContractFactory(contract_abi=swapped_contract_abi)
+        fn_name, arguments = db_tx_decoder.decode_transaction(
+            example_data, address=contract.address
+        )
+        self.assertEqual(fn_name, "buyDroid")
+        self.assertEqual(arguments, {"numberOfDroids": "4", "droidId": "10"})
+        self.assertIn((contract.address,), DbTxDecoder.cache_abis_by_address)

--- a/safe_transaction_service/contracts/tests/test_tx_decoder.py
+++ b/safe_transaction_service/contracts/tests/test_tx_decoder.py
@@ -208,7 +208,7 @@ class TestTxDecoder(TestCase):
             },
         ]
         # Get just the multisend object
-        self.assertEqual(tx_decoder._get_data_decoded_for_multisend(data), expected)
+        self.assertEqual(tx_decoder.decode_multisend_data(data), expected)
 
         # Now decode all the data
         expected = (
@@ -274,7 +274,7 @@ class TestTxDecoder(TestCase):
             "000000"
         )
         tx_decoder = get_tx_decoder()
-        self.assertEqual(tx_decoder._get_data_decoded_for_multisend(data), [])
+        self.assertEqual(tx_decoder.decode_multisend_data(data), [])
         self.assertEqual(
             tx_decoder.decode_transaction_with_types(data),
             (

--- a/safe_transaction_service/contracts/tx_decoder.py
+++ b/safe_transaction_service/contracts/tx_decoder.py
@@ -561,6 +561,8 @@ class DbTxDecoder(TxDecoder):
                     contract_selectors_with_abis
                     and selector in contract_selectors_with_abis
                 ):
+                    # If the selector is available in the abi specific for the address we will use that one
+                    # Otherwise we fallback to the general abi that matches the selector
                     return contract_selectors_with_abis[selector]
             return self.fn_selectors_with_abis[selector]
 

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -1036,8 +1036,7 @@ class OwnersView(APIView):
 
 
 class DataDecoderView(GenericAPIView):
-    def get_serializer_class(self):
-        return serializers.DataDecoderSerializer
+    serializer_class = serializers.DataDecoderSerializer
 
     @swagger_auto_schema(
         responses={
@@ -1058,7 +1057,9 @@ class DataDecoderView(GenericAPIView):
                 status=status.HTTP_422_UNPROCESSABLE_ENTITY, data=serializer.errors
             )
         else:
-            data_decoded = get_data_decoded_from_data(serializer.data["data"])
+            data_decoded = get_data_decoded_from_data(
+                serializer.data["data"], address=serializer.data["to"]
+            )
             if data_decoded:
                 return Response(status=status.HTTP_200_OK, data=data_decoded)
             else:


### PR DESCRIPTION
### What was wrong?

- When there's an ABI function selector colliding, sometimes a wrong decoder is used
- Closes #638

### How was it fixed?

Refactor `SafeTxDecoder`:
- Add a method `get_abi_function` to get the proper abi for data and an optional contract `address`.
- Pass always the `contract address` with the `data` to be decoded

Refactor `DbTxDecoder`:
- If the contract address has an ABI on database and can decode the `data` it will be used first 

Add `to` for the data decoding endpoint