### PR TITLE
Bump gnosis-py to v3.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,9 +19,8 @@ djangorestframework==3.13.1
 djangorestframework-camel-case==1.3.0
 docutils==0.18.1
 drf-yasg[validation]==1.20.0
-ethereum==2.3.2
 firebase-admin==5.2.0
-gnosis-py[django]==3.7.8
+gnosis-py[django]==3.8.0
 gunicorn[gevent]==20.1.0
 hexbytes==0.2.2
 packaging>=21.0


### PR DESCRIPTION
- Remove `pyethereum` dependency, as it's not needed anymore