### PR TITLE
Fix contract caching error

### DIFF
--- a/safe_transaction_service/__init__.py
+++ b/safe_transaction_service/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.2.1"
+__version__ = "4.2.2"
 __version_info__ = tuple(
     [
         int(num) if num.isdigit() else num

--- a/safe_transaction_service/contracts/views.py
+++ b/safe_transaction_service/contracts/views.py
@@ -19,9 +19,14 @@ class ContractView(RetrieveAPIView):
         if not (response := django_cache.get(cache_key)):
             response = super().get(request, address, *args, **kwargs)
             response.add_post_render_callback(
-                lambda r: django_cache.set(
-                    cache_key, r, timeout=60 * 60
-                )  # Cache 1 hour
+                lambda r: (
+                    django_cache.set(
+                        cache_key, response, timeout=60 * 60
+                    ),  # Cache 1 hour:
+                    r,
+                )[
+                    1
+                ]  # Return r, if not redis has issues
             )
         return response
 


### PR DESCRIPTION
- When redis cache backend is used response should be returned after calling `add_post_render_callback`. [More info](https://docs.djangoproject.com/en/4.0/ref/template-response/#django.template.response.SimpleTemplateResponse.add_post_render_callback)
