### PR TITLE
Use production config as default

### DIFF
--- a/config/celery_app.py
+++ b/config/celery_app.py
@@ -26,7 +26,7 @@ def on_celery_setup_logging(**kwargs):
 
 
 # set the default Django settings module for the 'celery' program.
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.local")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.production")
 
 app = Celery("safe_transaction_service")
 

--- a/manage.py
+++ b/manage.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.local")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.production")
 
     try:
         from django.core.management import execute_from_command_line


### PR DESCRIPTION
- Use `config.settings.production` instead of `config.settings.local` as a default for the service
- This means that if `DJANGO_SETTINGS_MODULE` is not set, the production config will be used.