### PR TITLE
Add Vscode default configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,4 @@ safe_transaction_service/media
 
 # User-specific stuff:
 .idea/
+.vscode/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Django: Run tests",
+            "type": "python",
+            "request": "launch",
+            "module": "pytest",
+            "args": [
+                "--lf",
+                "-rxXs"
+            ],
+            "django": true,
+            "envFile": ".env.test"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "python.formatting.provider": "black",
+    "python.linting.flake8Enabled": true,
+    "python.testing.pytestArgs": [],
+    "python.testing.pytestEnabled": true,
+    "python.testing.unittestEnabled": false,
+    "python.linting.enabled": true
+}


### PR DESCRIPTION
- Running/debugging tests should be working
- `.vscode` folder is excluded on `.gitignore` as this is the basic template but it needs to be modified by the user, e.g. adding information about Python environment. That will be done by `vscode` run running it for the first time