### PR TITLE
Be less restrictive when setting service out of sync

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -410,6 +410,10 @@ if NOTIFICATIONS_FIREBASE_CREDENTIALS_PATH:
         )
     )
 
+# Percentage of Safes allowed to be out of sync without alerting. By default 10%
+ALERT_OUT_OF_SYNC_EVENTS_THRESHOLD = env.float(
+    "ALERT_OUT_OF_SYNC_EVENTS_THRESHOLD", default=0.1
+)
 
 # AWS S3 https://github.com/etianen/django-s3-storage
 # AWS_QUERYSTRING_AUTH = False  # Remove query parameter authentication from generated URLs


### PR DESCRIPTION
- If less than 10% of contracts are out of sync for ERC20/ERC721, consider service synced
- That will prevent a lot of alerts when only one new or two contracts are out of sync
