### PR TITLE
Redact token value from hook logs

### DIFF
--- a/safe_transaction_service/history/tasks.py
+++ b/safe_transaction_service/history/tasks.py
@@ -428,7 +428,7 @@ def send_webhook_task(address: Optional[str], payload: Dict[str, Any]) -> int:
             logger.warning(
                 "Webhook failed with status-code=%d posting to url=%s with content=%s",
                 r.status_code,
-                full_url,
+                base_url,
                 r.content,
             )
 


### PR DESCRIPTION
- We are using `full_url` if the Webhook called failed with an error status – we should use `base_url` so that the token is not logged