### PR TITLE
Bump Django to v4

### DIFF
--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -68,13 +68,7 @@ if env.bool("USE_DOCKER", default=False):
 
     CACHES = {
         "default": {
-            "BACKEND": "django_redis.cache.RedisCache",
+            "BACKEND": "django.core.cache.backends.redis.RedisCache",
             "LOCATION": env("REDIS_URL"),
-            "OPTIONS": {
-                "CLIENT_CLASS": "django_redis.client.DefaultClient",
-                # Mimicing memcache behavior.
-                # http://niwinz.github.io/django-redis/latest/#_memcached_exceptions_behavior
-                "IGNORE_EXCEPTIONS": True,
-            },
         }
     }

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -17,14 +17,8 @@ DATABASES["default"]["ATOMIC_REQUESTS"] = False  # noqa F405
 # ------------------------------------------------------------------------------
 CACHES = {
     "default": {
-        "BACKEND": "django_redis.cache.RedisCache",
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
         "LOCATION": env("REDIS_URL"),
-        "OPTIONS": {
-            "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            # Mimicing memcache behavior.
-            # http://niwinz.github.io/django-redis/latest/#_memcached_exceptions_behavior
-            "IGNORE_EXCEPTIONS": True,
-        },
     }
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.21.3
 cachetools==5.0.0
 celery==5.2.3
-django==3.2.12
+django==4.0.2
 django-authtools==1.7.0
 django-cache-memoize==0.1.10
 django-celery-beat==2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ celery==5.2.3
 django==4.0.2
 django-authtools==1.7.0
 django-cache-memoize==0.1.10
-django-celery-beat==2.2.1
+# django-celery-beat==2.2.1  TODO Uncomment when updated
 django-cors-headers==3.11.0
 django-db-geventpool==4.0.0
 django-debug-toolbar
@@ -13,7 +13,6 @@ django-environ==0.8.1
 django-filter==21.1
 django-imagekit==4.1.0
 django-model-utils==4.2.0
-django-redis==5.2.0
 django-s3-storage==0.13.6
 django-timezone-field==4.2.3
 djangorestframework==3.13.1
@@ -21,9 +20,11 @@ djangorestframework-camel-case==1.3.0
 docutils==0.18.1
 drf-yasg[validation]==1.20.0
 firebase-admin==5.2.0
+git+https://github.com/celery/django-celery-beat@716a46ed34dc64c179fcf022b2aa6e7db146c947
 gnosis-py[django]==3.8.1
 gunicorn[gevent]==20.1.0
 hexbytes==0.2.2
+hiredis==2.0.0
 packaging>=21.0
 pillow==9.0.1
 psycogreen==1.0.2


### PR DESCRIPTION
- Bump django from 3.2.11 to 4.0.2
- Remove not needed django-redis
