### PR TITLE
Fix EthereumBlock search on admin

### DIFF
--- a/safe_transaction_service/history/admin.py
+++ b/safe_transaction_service/history/admin.py
@@ -83,7 +83,7 @@ class SafeContractDelegateInline(admin.TabularInline):
 
 # Admin models ------------------------------
 @admin.register(EthereumBlock)
-class EthereumBlockAdmin(BinarySearchAdmin):
+class EthereumBlockAdmin(admin.ModelAdmin):
     date_hierarchy = "timestamp"
     inlines = (EthereumTxInline,)
     list_display = (
@@ -95,7 +95,7 @@ class EthereumBlockAdmin(BinarySearchAdmin):
         "block_hash",
     )
     list_filter = ("confirmed",)
-    search_fields = ["number", "=block_hash"]
+    search_fields = ["number"]
     ordering = ["-number"]
 
 


### PR DESCRIPTION
- There was a parsing error due to `block_number` receiving a string value if `block_hash` was provided
- Even if it's desired to be able to filter using the 2 fields, `block_hash` was removed from the search
