### PR TITLE
Fix admin search for integer fields

### DIFF
--- a/safe_transaction_service/history/admin.py
+++ b/safe_transaction_service/history/admin.py
@@ -95,7 +95,10 @@ class EthereumBlockAdmin(admin.ModelAdmin):
         "block_hash",
     )
     list_filter = ("confirmed",)
-    search_fields = ["number"]
+    search_fields = [
+        "number",
+        "=block_hash",
+    ]
     ordering = ["-number"]
 
 

--- a/safe_transaction_service/utils/admin.py
+++ b/safe_transaction_service/utils/admin.py
@@ -34,7 +34,7 @@ class BinarySearchAdmin(admin.ModelAdmin):
                                 ]
                             }
                         )
-                except ValidationError:
+                except (ValidationError, ValueError):
                     pass
         return queryset, may_have_duplicates
 


### PR DESCRIPTION
- When trying to search for a field using a string in the admin field, there was an error 500
- For example, if searching for a `blockHash` there was an error when trying to format the string to a integer