### PR TITLE
Return `trusted` as part of the MultisigTransaction

### DIFF
--- a/safe_transaction_service/history/serializers.py
+++ b/safe_transaction_service/history/serializers.py
@@ -570,6 +570,7 @@ class SafeMultisigTransactionResponseSerializer(SafeMultisigTxSerializerV1):
     data_decoded = serializers.SerializerMethodField()
     confirmations_required = serializers.IntegerField()
     confirmations = serializers.SerializerMethodField()
+    trusted = serializers.BooleanField()
     signatures = HexadecimalField(allow_null=True, required=False)
 
     def get_block_number(self, obj: MultisigTransaction) -> Optional[int]:

--- a/safe_transaction_service/history/tests/test_views.py
+++ b/safe_transaction_service/history/tests/test_views.py
@@ -507,6 +507,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             response.data["transaction_hash"], multisig_tx.ethereum_tx.tx_hash
         )
         self.assertEqual(response.data["origin"], multisig_tx.origin)
+        self.assertFalse(response.data["trusted"])
         self.assertEqual(
             response.data["data_decoded"],
             {
@@ -846,6 +847,7 @@ class TestViews(SafeTestCaseMixin, APITestCase):
             response.data["results"][0]["confirmations"][0]["signature"],
             data["signature"],
         )
+        self.assertTrue(response.data["results"][0]["trusted"])
 
         # Sign with a different user that sender
         random_user_account = Account.create()


### PR DESCRIPTION
- Trusted gives information about the transaction. Transaction will be trusted if at least one owner of the Safe signed it, it's executed or someone with enough privileges created it
